### PR TITLE
Clean up dependencies

### DIFF
--- a/src/Winton.Extensions.Configuration.Consul/project.json
+++ b/src/Winton.Extensions.Configuration.Consul/project.json
@@ -6,9 +6,8 @@
   },
   "dependencies": {
     "Consul": "0.7.0.3",
-    "Microsoft.Extensions.Configuration.Abstractions": "1.0.0",
-    "Microsoft.Extensions.Configuration.Json": "1.0.0",
-    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0"
+    "Microsoft.Extensions.Configuration": "1.0.0",
+    "Newtonsoft.Json": "9.0.1"
   },
   "description": "Provides support for configuring .Net Core applications with Consul",
   "frameworks": {

--- a/test/Website/project.json
+++ b/test/Website/project.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.1"
+      "version": "1.1.0"
     },
     "Microsoft.AspNetCore.Mvc": "1.0.1",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",

--- a/test/Winton.Extensions.Configuration.Consul.Test/project.json
+++ b/test/Winton.Extensions.Configuration.Consul.Test/project.json
@@ -2,7 +2,7 @@
     "dependencies": {
         "dotnet-test-nunit": "3.4.0-beta-3",
         "Microsoft.NETCore.App": {
-            "version": "1.0.1",
+            "version": "1.1.0",
             "type": "platform"
         },
         "Moq": "4.6.38-alpha",


### PR DESCRIPTION
Summary
* Remove unnecessary dependency on Microsoft.Extensions.Configuration.son and instead depend on the actual packages that are being referenced in code.
* Update tests and samples to .NET Core 1.1.0