### PR TITLE
Add StyleCop static analysis and fix errors.

### DIFF
--- a/RuleSet.xml
+++ b/RuleSet.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RuleSet Name="WintonCode ruleset" ToolsVersion="12.0">
+  <Rules AnalyzerId="StyleCop.Analyzers"
+         RuleNamespace="StyleCop.Analyzers.ReadabilityRules">
+    <Rule Id="SA1101" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers"
+         RuleNamespace="StyleCop.Analyzers.NamingRules">
+    <Rule Id="SA1309" Action="None" />
+  </Rules>
+</RuleSet>

--- a/src/Winton.Extensions.Configuration.Consul/ConfigQueryResult.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConfigQueryResult.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Winton. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+
 using System.Net;
 using Consul;
 

--- a/src/Winton.Extensions.Configuration.Consul/ConfigurationBuilderExtensions.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConfigurationBuilderExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Winton. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+
 using System;
 using System.Threading;
 using Microsoft.Extensions.Configuration;
@@ -5,7 +8,7 @@ using Microsoft.Extensions.Configuration;
 namespace Winton.Extensions.Configuration.Consul
 {
     /// <summary>
-    /// Extensions for the <see cref="IConfigurationBuilder"/> that provide syntactic sugar for 
+    /// Extensions for the <see cref="IConfigurationBuilder"/> that provide syntactic sugar for
     /// using the <see cref="IConsulConfigurationSource"/>.
     /// </summary>
     public static class ConfigurationBuilderExtensions
@@ -20,7 +23,7 @@ namespace Winton.Extensions.Configuration.Consul
         /// <returns>The builder</returns>
         public static IConfigurationBuilder AddConsul(this IConfigurationBuilder builder, string key, CancellationToken cancellationToken)
         {
-            return builder.AddConsul(key, cancellationToken, options => {});
+            return builder.AddConsul(key, cancellationToken, options => { });
         }
 
         /// <summary>

--- a/src/Winton.Extensions.Configuration.Consul/ConsulClientFactory.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulClientFactory.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Winton. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+
 using Consul;
 
 namespace Winton.Extensions.Configuration.Consul

--- a/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationClient.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationClient.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Winton. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+
 using System;
 using System.Net;
 using System.Threading;
@@ -11,7 +14,7 @@ namespace Winton.Extensions.Configuration.Consul
     internal sealed class ConsulConfigurationClient : IConsulConfigurationClient
     {
         private readonly IConsulClientFactory _consulClientFactory;
-        private readonly Object _lastIndexLock = new Object();
+        private readonly object _lastIndexLock = new object();
         private readonly IConsulConfigurationSource _source;
 
         private ConfigurationReloadToken _reloadToken = new ConfigurationReloadToken();
@@ -80,6 +83,7 @@ namespace Winton.Extensions.Configuration.Consul
             {
                 queryOptions = new QueryOptions { WaitIndex = _lastIndex };
             }
+
             var result = await GetKVPair(queryOptions);
             return result != null && UpdateLastIndex(result);
         }
@@ -94,6 +98,7 @@ namespace Winton.Extensions.Configuration.Consul
                     return true;
                 }
             }
+
             return false;
         }
     }

--- a/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationProvider.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationProvider.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Winton. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -18,6 +21,7 @@ namespace Winton.Extensions.Configuration.Consul
             {
                 throw new ArgumentNullException(nameof(source.Parser));
             }
+
             _consulConfigClient = consulConfigClient;
             _source = source;
 
@@ -25,11 +29,11 @@ namespace Winton.Extensions.Configuration.Consul
             {
                 ChangeToken.OnChange(
                     () => _consulConfigClient.Watch(_source.OnWatchException),
-                    async () => {
+                    async () =>
+                    {
                         await DoLoad(reloading: true);
                         OnReload();
-                    }
-                );
+                    });
             }
         }
 
@@ -61,10 +65,11 @@ namespace Winton.Extensions.Configuration.Consul
                         // Don't overwrite mandatory config with empty data if not found when reloading
                         return;
                     }
-                } 
+                }
+
                 LoadIntoMemory(configQueryResult);
             }
-            catch(Exception exception)
+            catch (Exception exception)
             {
                 HandleLoadException(exception);
             }

--- a/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationSource.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationSource.cs
@@ -1,10 +1,13 @@
+// Copyright (c) Winton. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+
 using System;
 using System.Net.Http;
 using System.Threading;
-using Winton.Extensions.Configuration.Consul.Parsers;
-using Winton.Extensions.Configuration.Consul.Parsers.Json;
 using Consul;
 using Microsoft.Extensions.Configuration;
+using Winton.Extensions.Configuration.Consul.Parsers;
+using Winton.Extensions.Configuration.Consul.Parsers.Json;
 
 namespace Winton.Extensions.Configuration.Consul
 {

--- a/src/Winton.Extensions.Configuration.Consul/ConsulLoadExceptionContext.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulLoadExceptionContext.cs
@@ -1,9 +1,12 @@
+// Copyright (c) Winton. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+
 using System;
 
 namespace Winton.Extensions.Configuration.Consul
 {
     /// <summary>
-    /// Contains information about exceptions that occuring during a configuration load from Consul.
+    /// Contains information about exceptions that occur during a configuration load from Consul.
     /// </summary>
     public sealed class ConsulLoadExceptionContext
     {
@@ -14,18 +17,19 @@ namespace Winton.Extensions.Configuration.Consul
         }
 
         /// <summary>
-        /// The exception that occured in Load.
+        /// Gets the <see cref="Exception"/> that occured in Load.
         /// </summary>
         public Exception Exception { get; }
 
         /// <summary>
-        /// Set to true to prevent the exception from being thrown. 
+        /// Gets or sets a value indicating whether the exception should be ignored.
+        /// Set to true to prevent the exception from being thrown.
         /// I.e. if the exception has been handled.
         /// </summary>
         public bool Ignore { get; set; }
 
         /// <summary>
-        /// The <see cref="IConsulConfigurationSource"/> of the provider that caused the exception.
+        /// Gets the <see cref="IConsulConfigurationSource"/> of the provider that caused the exception.
         /// </summary>
         public IConsulConfigurationSource Source { get; }
     }

--- a/src/Winton.Extensions.Configuration.Consul/ConsulWatchExceptionContext.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulWatchExceptionContext.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Winton. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+
 using System;
 using System.Threading;
 
@@ -15,12 +18,12 @@ namespace Winton.Extensions.Configuration.Consul
         }
 
         /// <summary>
-        /// The exception that occured in Load.
+        /// Gets the <see cref="Exception"/> that occured.
         /// </summary>
         public Exception Exception { get; }
 
         /// <summary>
-        /// The <see cref="IConsulConfigurationSource"/> of the provider that caused the exception.
+        /// Gets the <see cref="IConsulConfigurationSource"/> of the provider that caused the exception.
         /// Can be used to access the <see cref="CancellationToken"/> which can terminate the watcher.
         /// </summary>
         public IConsulConfigurationSource Source { get; }

--- a/src/Winton.Extensions.Configuration.Consul/IConfigQueryResult.cs
+++ b/src/Winton.Extensions.Configuration.Consul/IConfigQueryResult.cs
@@ -1,9 +1,15 @@
+// Copyright (c) Winton. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+
 namespace Winton.Extensions.Configuration.Consul
 {
+    /// <summary>The result of a query for config in Consul.</summary>
     internal interface IConfigQueryResult
     {
+        /// <summary>Gets a value indicating whether the config exists.</summary>
         bool Exists { get; }
 
+        /// <summary>Gets the raw value of the config.</summary>
         byte[] Value { get; }
     }
 }

--- a/src/Winton.Extensions.Configuration.Consul/IConsulClientFactory.cs
+++ b/src/Winton.Extensions.Configuration.Consul/IConsulClientFactory.cs
@@ -1,9 +1,15 @@
+// Copyright (c) Winton. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+
 using Consul;
 
 namespace Winton.Extensions.Configuration.Consul
 {
+    /// <summary>A factory responsible for creating <see cref="IConsulClient"/> objects.</summary>
     internal interface IConsulClientFactory
     {
+        /// <summary>Creates a new instance of an <see cref="IConsulClient"/>.</summary>
+        /// <returns>A new <see cref="IConsulClient"/>.</returns>
         IConsulClient Create();
     }
 }

--- a/src/Winton.Extensions.Configuration.Consul/IConsulConfigurationClient.cs
+++ b/src/Winton.Extensions.Configuration.Consul/IConsulConfigurationClient.cs
@@ -1,13 +1,22 @@
+// Copyright (c) Winton. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Primitives;
 
 namespace Winton.Extensions.Configuration.Consul
 {
+    /// <summary>Provides client access for getting and watching config values in Consul.</summary>
     internal interface IConsulConfigurationClient
     {
+        /// <summary>Gets the config from consul asynchronously.</summary>
+        /// <returns>A Task containing the result of the query for the config.</returns>
         Task<IConfigQueryResult> GetConfig();
 
+        /// <summary>Watches the config for changes.</summary>
+        /// <param name="onException">An action to be invoked if an exception occurs during the watch.</param>
+        /// <returns>An <see cref="IChangeToken"/> that will indicated when changes have occured.</returns>
         IChangeToken Watch(Action<ConsulWatchExceptionContext> onException);
     }
 }

--- a/src/Winton.Extensions.Configuration.Consul/IConsulConfigurationSource.cs
+++ b/src/Winton.Extensions.Configuration.Consul/IConsulConfigurationSource.cs
@@ -1,10 +1,13 @@
+// Copyright (c) Winton. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+
 using System;
 using System.Net.Http;
 using System.Threading;
-using Winton.Extensions.Configuration.Consul.Parsers;
-using Winton.Extensions.Configuration.Consul.Parsers.Json;
 using Consul;
 using Microsoft.Extensions.Configuration;
+using Winton.Extensions.Configuration.Consul.Parsers;
+using Winton.Extensions.Configuration.Consul.Parsers.Json;
 
 namespace Winton.Extensions.Configuration.Consul
 {
@@ -14,64 +17,64 @@ namespace Winton.Extensions.Configuration.Consul
     public interface IConsulConfigurationSource : IConfigurationSource
     {
         /// <summary>
-        /// A <see cref="CancellationToken"/> that can be used to cancel any consul requests
+        /// Gets a <see cref="CancellationToken"/> that can be used to cancel any consul requests
         /// either loading or watching via long polling.
         /// It is recommended that this is cancelled during shut down.
         /// </summary>
         CancellationToken CancellationToken { get; }
 
         /// <summary>
-        /// An <see cref="Action"/> to be applied to the <see cref="ConsulClientConfiguration"/> 
+        /// Gets or sets an <see cref="Action"/> to be applied to the <see cref="ConsulClientConfiguration"/>
         /// during construction of the <see cref="IConsulClient"/>.
         /// Allows the default config options for Consul to be overriden.
         /// </summary>
         Action<ConsulClientConfiguration> ConsulConfigurationOptions { get; set; }
 
         /// <summary>
-        /// An <see cref="Action"/> to be applied to the <see cref="HttpClient"/> during 
+        /// Gets or sets an <see cref="Action"/> to be applied to the <see cref="HttpClient"/> during
         /// construction of the <see cref="IConsulClient"/>.
         /// Allows the default HTTP client options for Consul to be overriden.
         /// </summary>
         Action<HttpClient> ConsulHttpClientOptions { get; set; }
 
         /// <summary>
-        /// An <see cref="Action"/> to be applied to the <see cref="HttpClientHandler"/> 
+        /// Gets or sets an <see cref="Action"/> to be applied to the <see cref="HttpClientHandler"/>
         /// during construction of the <see cref="IConsulClient"/>.
         /// Allows the default HTTP client hander options for Consul to be overriden.
         /// </summary>
         Action<HttpClientHandler> ConsulHttpClientHandlerOptions { get; set; }
 
         /// <summary>
-        /// The key in Consul where the configuration is located.
+        /// Gets the key in Consul where the configuration is located.
         /// </summary>
         string Key { get; }
 
         /// <summary>
-        /// An <see cref="Action"/> that is invoked when an exception is raised during config load.
+        /// Gets or sets an <see cref="Action"/> that is invoked when an exception is raised during config load.
         /// Used by clients to handle the exception if possible and prevent it from being thrown.
         /// </summary>
         Action<ConsulLoadExceptionContext> OnLoadException { get; set; }
 
         /// <summary>
-        /// An <see cref="Action"/> that is invoked when an exception is raised whilst watching.
+        /// Gets or sets an <see cref="Action"/> that is invoked when an exception is raised whilst watching.
         /// Used by clients to acknowledge the excetion and possibly cancel the watcher.
         /// </summary>
         Action<ConsulWatchExceptionContext> OnWatchException { get; set; }
 
         /// <summary>
-        /// Determines if loading the config is optional.
+        /// Gets or sets a value indicating whether the config is optional.
         /// </summary>
         bool Optional { get; set; }
 
         /// <summary>
-        /// The <see cref="IConfigurationParser"/> to use when parsing the config.
+        /// Gets or sets the <see cref="IConfigurationParser"/> to use when parsing the config.
         /// Allows different data formats to be stored in consul under the given key.
         /// Defaults to <see cref="JsonConfigurationParser"/>.
         /// </summary>
         IConfigurationParser Parser { get; set; }
 
         /// <summary>
-        /// Determines whether the source will be loaded if the data in consul changes.
+        /// Gets or sets a value indicating whether the source will be reloaded if the data in consul changes.
         /// </summary>
         bool ReloadOnChange { get; set; }
     }

--- a/src/Winton.Extensions.Configuration.Consul/Parsers/IConfigurationParser.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Parsers/IConfigurationParser.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Winton. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+
 using System.Collections.Generic;
 using System.IO;
 
@@ -11,6 +14,8 @@ namespace Winton.Extensions.Configuration.Consul.Parsers
         /// <summary>
         /// Parse the <see cref="Stream"/> into a dictionary.
         /// </summary>
+        /// <param name="stream">The stream to parse.</param>
+        /// <returns>A dictionary representing the configuration in a flattened form.</returns>
         IDictionary<string, string> Parse(Stream stream);
     }
 }

--- a/src/Winton.Extensions.Configuration.Consul/Parsers/Json/JsonConfigurationParser.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Parsers/Json/JsonConfigurationParser.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Winton. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+
 using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;

--- a/src/Winton.Extensions.Configuration.Consul/Parsers/Json/JsonFlattener.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Parsers/Json/JsonFlattener.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Winton. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
@@ -16,8 +19,10 @@ namespace Winton.Extensions.Configuration.Consul.Parsers.Json
                 {
                     throw new FormatException($"Key {primitive.Key} is duplicated in json");
                 }
+
                 data.Add(primitive);
             }
+
             return data;
         }
     }

--- a/src/Winton.Extensions.Configuration.Consul/Parsers/Json/JsonPrimitiveVisitor.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Parsers/Json/JsonPrimitiveVisitor.cs
@@ -1,8 +1,11 @@
+// Copyright (c) Winton. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json.Linq;
 using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json.Linq;
 
 namespace Winton.Extensions.Configuration.Consul.Parsers.Json
 {
@@ -13,6 +16,7 @@ namespace Winton.Extensions.Configuration.Consul.Parsers.Json
         /// <summary>
         /// Recursively visits each primitive of the JSON object using depth-first traversal.
         /// </summary>
+        /// <param name="jObject">The jObject to visit.</param>
         /// <returns>A KV pair for the full path to the property and its value</returns>
         public ICollection<KeyValuePair<string, string>> VisitJObject(JObject jObject)
         {
@@ -59,8 +63,9 @@ namespace Winton.Extensions.Configuration.Consul.Parsers.Json
             {
                 throw new Exception("You're yielding so the context has changed by that time");
             }
+
             var key = ConfigurationPath.Combine(_context.Reverse());
-            return new[] {new KeyValuePair<string, string>(key, primitive.ToString())};
+            return new[] { new KeyValuePair<string, string>(key, primitive.ToString()) };
         }
     }
 }

--- a/src/Winton.Extensions.Configuration.Consul/Properties/AssemblyInfo.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Properties/AssemblyInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Winton. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Winton.Extensions.Configuration.Consul.Test")]

--- a/src/Winton.Extensions.Configuration.Consul/project.json
+++ b/src/Winton.Extensions.Configuration.Consul/project.json
@@ -1,5 +1,6 @@
 {
   "buildOptions": {
+    "additionalArguments": [ "/ruleset:../../RuleSet.xml", "/additionalfile:../../stylecop.json" ],
     "outputName": "Winton.Extensions.Configuration.Consul",
     "warningsAsErrors": true,
     "xmlDoc": true
@@ -7,7 +8,11 @@
   "dependencies": {
     "Consul": "0.7.0.3",
     "Microsoft.Extensions.Configuration": "1.0.0",
-    "Newtonsoft.Json": "9.0.1"
+    "Newtonsoft.Json": "9.0.1",
+    "StyleCop.Analyzers": {
+        "version": "1.1.0-beta001",
+        "type": "build"
+    }
   },
   "description": "Provides support for configuring .Net Core applications with Consul",
   "frameworks": {

--- a/stylecop.json
+++ b/stylecop.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/1.1.0-beta001/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "companyName": "Winton",
+      "copyrightText": "Copyright (c) {companyName}. All rights reserved.\nLicensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.",
+      "documentInternalElements": false,
+      "xmlHeader": false
+    },
+    "orderingRules": {
+      "blankLinesBetweenUsingGroups": "omit",
+      "usingDirectivesPlacement": "outsideNamespace"
+    }
+  }
+}

--- a/stylecop.json
+++ b/stylecop.json
@@ -7,6 +7,14 @@
       "documentInternalElements": false,
       "xmlHeader": false
     },
+    "maintainabilityRules": {
+      "topLevelTypes": [
+        "class",
+        "enum",
+        "interface",
+        "struct"
+      ]
+    },
     "orderingRules": {
       "blankLinesBetweenUsingGroups": "omit",
       "usingDirectivesPlacement": "outsideNamespace"


### PR DESCRIPTION
Summary
* Add StyleCop
* Turn off rules about always using `this` rather than `_` for referencing private class members
* Fix all other StyleCop rule violations