### PR TITLE
Change AppVeyor and Travis configs to skip builds for tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: csharp
 sudo: required
+branches:
+  except:
+  - /^[0-9]/
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ os:
   - osx
 osx_image: xcode7.3
 before_install:
-  - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
+  - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; ln -s -f /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s -f /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
 script:
   - git fetch --unshallow
   - if test "$TRAVIS_PULL_REQUEST" == "false"; then ./build.sh -v; else ./build.sh; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ skip_tags: true
 build_script:
   - ps: .\build.ps1 -VersionAndPublish (-Not $env:APPVEYOR_PULL_REQUEST_NUMBER)
 test: off
-artifacts:  
+artifacts:
 - path: .\**\*.nupkg
   name: NuGet
 nuget:
@@ -17,5 +17,6 @@ deploy:
   api_key:
     secure: CxMH3k6k/Rpz1zjToGDAelLWDT/gDqRo08iEUAQsRnL+WRo+4TL5gLiNEUy/GfUy
   on:
-    branch: master
-    branch: release
+    branch: 
+    - master
+    - release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ environment:
   CLI_VERSION: latest
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+skip_tags: true
 build_script:
   - ps: .\build.ps1 -VersionAndPublish (-Not $env:APPVEYOR_PULL_REQUEST_NUMBER)
 test: off
@@ -17,3 +18,4 @@ deploy:
     secure: CxMH3k6k/Rpz1zjToGDAelLWDT/gDqRo08iEUAQsRnL+WRo+4TL5gLiNEUy/GfUy
   on:
     branch: master
+    branch: release


### PR DESCRIPTION
Summary
 - Change appveyor and travis config to skip builds for tags as otherwise double builds occur when creating a release.
- Allow AppVeyor to publish to nuget from release branch