### PR TITLE
Use regex to match release branches in AppVeyor publish config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,4 +19,4 @@ deploy:
   on:
     branch: 
     - master
-    - release
+    - /release\/[0-9]\.[0-9]/


### PR DESCRIPTION
Summary
- Change appveyor.yml NuGet deploy config to publish branches matching `release\/[0-9]\.[0-9]`