### PR TITLE
Change source file header text from LICENCE.md to LICENCE

### DIFF
--- a/src/Winton.Extensions.Configuration.Consul/ConfigQueryResult.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConfigQueryResult.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Winton. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See LICENCE in the project root for license information.
 
 using System.Net;
 using Consul;

--- a/src/Winton.Extensions.Configuration.Consul/ConfigurationBuilderExtensions.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConfigurationBuilderExtensions.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Winton. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See LICENCE in the project root for license information.
 
 using System;
 using System.Threading;

--- a/src/Winton.Extensions.Configuration.Consul/ConsulClientFactory.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulClientFactory.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Winton. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See LICENCE in the project root for license information.
 
 using Consul;
 

--- a/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationClient.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationClient.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Winton. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See LICENCE in the project root for license information.
 
 using System;
 using System.Net;

--- a/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationProvider.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationProvider.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Winton. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See LICENCE in the project root for license information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationSource.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationSource.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Winton. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See LICENCE in the project root for license information.
 
 using System;
 using System.Net.Http;

--- a/src/Winton.Extensions.Configuration.Consul/ConsulLoadExceptionContext.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulLoadExceptionContext.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Winton. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See LICENCE in the project root for license information.
 
 using System;
 

--- a/src/Winton.Extensions.Configuration.Consul/ConsulWatchExceptionContext.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulWatchExceptionContext.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Winton. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See LICENCE in the project root for license information.
 
 using System;
 using System.Threading;

--- a/src/Winton.Extensions.Configuration.Consul/IConfigQueryResult.cs
+++ b/src/Winton.Extensions.Configuration.Consul/IConfigQueryResult.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Winton. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See LICENCE in the project root for license information.
 
 namespace Winton.Extensions.Configuration.Consul
 {

--- a/src/Winton.Extensions.Configuration.Consul/IConsulClientFactory.cs
+++ b/src/Winton.Extensions.Configuration.Consul/IConsulClientFactory.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Winton. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See LICENCE in the project root for license information.
 
 using Consul;
 

--- a/src/Winton.Extensions.Configuration.Consul/IConsulConfigurationClient.cs
+++ b/src/Winton.Extensions.Configuration.Consul/IConsulConfigurationClient.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Winton. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See LICENCE in the project root for license information.
 
 using System;
 using System.Threading.Tasks;

--- a/src/Winton.Extensions.Configuration.Consul/IConsulConfigurationSource.cs
+++ b/src/Winton.Extensions.Configuration.Consul/IConsulConfigurationSource.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Winton. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See LICENCE in the project root for license information.
 
 using System;
 using System.Net.Http;

--- a/src/Winton.Extensions.Configuration.Consul/Parsers/IConfigurationParser.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Parsers/IConfigurationParser.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Winton. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See LICENCE in the project root for license information.
 
 using System.Collections.Generic;
 using System.IO;

--- a/src/Winton.Extensions.Configuration.Consul/Parsers/Json/JsonConfigurationParser.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Parsers/Json/JsonConfigurationParser.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Winton. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See LICENCE in the project root for license information.
 
 using System.Collections.Generic;
 using System.IO;

--- a/src/Winton.Extensions.Configuration.Consul/Parsers/Json/JsonFlattener.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Parsers/Json/JsonFlattener.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Winton. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See LICENCE in the project root for license information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Winton.Extensions.Configuration.Consul/Parsers/Json/JsonPrimitiveVisitor.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Parsers/Json/JsonPrimitiveVisitor.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Winton. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See LICENCE in the project root for license information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Winton.Extensions.Configuration.Consul/Properties/AssemblyInfo.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Winton. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See LICENCE.md in the project root for license information.
+// Licensed under the Apache License, Version 2.0. See LICENCE in the project root for license information.
 
 using System.Runtime.CompilerServices;
 


### PR DESCRIPTION
Summary
* Changed LICENCE.md to LICENCE in header text of source files.