### PR TITLE
Bump versions of all dependencies

### DIFF
--- a/src/Winton.Extensions.Configuration.Consul/Winton.Extensions.Configuration.Consul.csproj
+++ b/src/Winton.Extensions.Configuration.Consul/Winton.Extensions.Configuration.Consul.csproj
@@ -3,17 +3,17 @@
   <PropertyGroup>
     <Authors>Winton</Authors>
     <Company>Winton</Company>
-    <Copyright>Copyright 2017 Winton</Copyright>
-    <Description>Provides support for configuring .Net Core applications with Consul</Description>
+    <Copyright>Copyright 2018 Winton</Copyright>
+    <Description>Provides support for configuring .NET Core applications with Consul</Description>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <GetVersion>False</GetVersion>
-    <NoWarn>$(NoWarn);SA1101;SA1309;SA1413</NoWarn>
+    <NoWarn>$(NoWarn);SA1101;SA1309;SA1413;</NoWarn>
     <PackageId>Winton.Extensions.Configuration.Consul</PackageId>
     <PackageIconUrl>https://raw.githubusercontent.com/wintoncode/Winton.Extensions.Configuration.Consul/master/icon.jpg</PackageIconUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/wintoncode/Winton.Extensions.Configuration.Consul/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/wintoncode/Winton.Extensions.Configuration.Consul</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
-    <PackageTags>.Net;.Net Core;dotnetcore;Asp.Net;Asp.Net Core;aspnetcore;configuration;consul;winton;wintoncode</PackageTags>
+    <PackageTags>.NET;Core;dotnetcore;ASP.NET;aspnetcore;configuration;consul;winton;wintoncode</PackageTags>
     <PackageVersion>$(NuGetVersion)</PackageVersion>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/wintoncode/Winton.Extensions.Configuration.Consul</RepositoryUrl>
@@ -31,10 +31,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Consul" Version="0.7.0.3" />
+    <PackageReference Include="Consul" Version="0.7.2.3" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0011" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 

--- a/test/Website/Dockerfile
+++ b/test/Website/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.1.4-runtime
+FROM microsoft/dotnet:1.1.5-runtime
 
 COPY bin/Release/netcoreapp1.1/publish /app
 WORKDIR /app

--- a/test/Website/Startup.cs
+++ b/test/Website/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Swashbuckle.AspNetCore.Swagger;
 
 namespace Winton.Extensions.Configuration.Consul.Website
 {
@@ -44,9 +45,12 @@ namespace Winton.Extensions.Configuration.Consul.Website
         public void ConfigureServices(IServiceCollection services)
         {
             services
+                .AddSwaggerGen(c =>
+                {
+                    c.SwaggerDoc("v1", new Info { Title = "Test Website", Version = "v1" });
+                })
                 .AddSingleton(_configuration)
                 .AddMvc();
-            services.AddSwaggerGen();
         }
 
         public void Configure(IApplicationBuilder app, IApplicationLifetime appLifetime)
@@ -54,7 +58,10 @@ namespace Winton.Extensions.Configuration.Consul.Website
             app
                 .UseMvc()
                 .UseSwagger()
-                .UseSwaggerUi("swagger");
+                .UseSwaggerUI(c =>
+                {
+                    c.SwaggerEndpoint("/swagger/v1/swagger.json", "Test Website");
+                });
 
             appLifetime.ApplicationStopping.Register(_consulConfigCancellationTokenSource.Cancel);
         }

--- a/test/Website/Website.csproj
+++ b/test/Website/Website.csproj
@@ -17,18 +17,14 @@
     <Folder Include="wwwroot\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.6" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
-    <PackageReference Include="Swashbuckle" Version="6.0.0-beta902" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Winton.Extensions.Configuration.Consul\Winton.Extensions.Configuration.Consul.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.1" />
   </ItemGroup>
 
 </Project>

--- a/test/Winton.Extensions.Configuration.Consul.Test/ConsulConfigurationClientTests.cs
+++ b/test/Winton.Extensions.Configuration.Consul.Test/ConsulConfigurationClientTests.cs
@@ -29,14 +29,14 @@ namespace Winton.Extensions.Configuration.Consul
             _cancellationToken = _cancellationTokenSource.Token;
 
             _consulConfigurationSourceMock = new Mock<IConsulConfigurationSource>(MockBehavior.Strict);
-            _consulConfigurationSourceMock.SetupGet(ccs => ccs.CancellationToken).Returns(_cancellationToken);
-            _consulConfigurationSourceMock.SetupGet(ccs => ccs.Key).Returns(_Key);
+            _consulConfigurationSourceMock.Setup(ccs => ccs.CancellationToken).Returns(_cancellationToken);
+            _consulConfigurationSourceMock.Setup(ccs => ccs.Key).Returns(_Key);
 
             _kvMock = new Mock<IKVEndpoint>(MockBehavior.Strict);
 
             _consulClientMock = new Mock<IConsulClient>(MockBehavior.Strict);
             _consulClientMock.Setup(cc => cc.Dispose());
-            _consulClientMock.SetupGet(cc => cc.KV).Returns(_kvMock.Object);
+            _consulClientMock.Setup(cc => cc.KV).Returns(_kvMock.Object);
             _consulClientFactoryMock = new Mock<IConsulClientFactory>(MockBehavior.Strict);
             _consulClientFactoryMock.Setup(ccf => ccf.Create()).Returns(_consulClientMock.Object);
 

--- a/test/Winton.Extensions.Configuration.Consul.Test/ConsulConfigurationProviderTests.cs
+++ b/test/Winton.Extensions.Configuration.Consul.Test/ConsulConfigurationProviderTests.cs
@@ -27,12 +27,12 @@ namespace Winton.Extensions.Configuration.Consul
         {
             _configParserMock = new Mock<IConfigurationParser>(MockBehavior.Strict);
             _consulConfigSourceMock = new Mock<IConsulConfigurationSource>(MockBehavior.Strict);
-            _consulConfigSourceMock.SetupGet(ccs => ccs.Parser).Returns(_configParserMock.Object);
-            _consulConfigSourceMock.SetupGet(ccs => ccs.Key).Returns(_Key);
-            _consulConfigSourceMock.SetupGet(ccs => ccs.Optional).Returns(false);
-            _consulConfigSourceMock.SetupGet(ccs => ccs.ReloadOnChange).Returns(false);
-            _consulConfigSourceMock.SetupGet(ccs => ccs.OnLoadException).Returns(null);
-            _consulConfigSourceMock.SetupGet(ccs => ccs.OnWatchException).Returns(null);
+            _consulConfigSourceMock.Setup(ccs => ccs.Parser).Returns(_configParserMock.Object);
+            _consulConfigSourceMock.Setup(ccs => ccs.Key).Returns(_Key);
+            _consulConfigSourceMock.Setup(ccs => ccs.Optional).Returns(false);
+            _consulConfigSourceMock.Setup(ccs => ccs.ReloadOnChange).Returns(false);
+            _consulConfigSourceMock.Setup(ccs => ccs.OnLoadException).Returns(null);
+            _consulConfigSourceMock.Setup(ccs => ccs.OnWatchException).Returns(() => ctx => { });
 
             _changeTokenMock = new Mock<IChangeToken>(MockBehavior.Strict);
             _configQueryResultMock = new Mock<IConfigQueryResult>(MockBehavior.Strict);
@@ -52,7 +52,7 @@ namespace Winton.Extensions.Configuration.Consul
         [Test]
         public void ShouldThrowIfParserIsNullWhenConstructed()
         {
-            _consulConfigSourceMock.SetupGet(ccs => ccs.Parser).Returns((IConfigurationParser)null);
+            _consulConfigSourceMock.Setup(ccs => ccs.Parser).Returns((IConfigurationParser)null);
 
             Assert.That(
                 () => new ConsulConfigurationProvider(_consulConfigSourceMock.Object, _consulConfigClientMock.Object),
@@ -77,7 +77,7 @@ namespace Winton.Extensions.Configuration.Consul
         [Test]
         public void ShouldHaveEmptyDataIfConfigDoesNotExistdAndIsOptional()
         {
-            _consulConfigSourceMock.SetupGet(ccs => ccs.Optional).Returns(true);
+            _consulConfigSourceMock.Setup(ccs => ccs.Optional).Returns(true);
             _configQueryResultMock.Setup(cqr => cqr.Exists).Returns(false);
 
             _consulConfigProvider.Load();
@@ -90,7 +90,7 @@ namespace Winton.Extensions.Configuration.Consul
         [Test]
         public void ShouldNotParseIfConfigBytesIsNullWhenLoad()
         {
-            _consulConfigSourceMock.SetupGet(ccs => ccs.Optional).Returns(true);
+            _consulConfigSourceMock.Setup(ccs => ccs.Optional).Returns(true);
             _configQueryResultMock.Setup(cqr => cqr.Exists).Returns(false);
 
             _consulConfigProvider.Load();
@@ -104,11 +104,11 @@ namespace Winton.Extensions.Configuration.Consul
         public void ShouldThrowIfConfigDoesNotExistAndIsNotOptonalWhenLoad()
         {
             ConsulLoadExceptionContext actualExceptionContext = null;
-            _consulConfigSourceMock.SetupGet(ccs => ccs.Optional).Returns(false);
+            _consulConfigSourceMock.Setup(ccs => ccs.Optional).Returns(false);
             _configQueryResultMock.Setup(cqr => cqr.Exists).Returns(false);
 
             _consulConfigSourceMock
-                .SetupGet(ccs => ccs.OnLoadException)
+                .Setup(ccs => ccs.OnLoadException)
                 .Returns(exceptionContext =>
                 {
                     actualExceptionContext = exceptionContext;
@@ -134,7 +134,7 @@ namespace Winton.Extensions.Configuration.Consul
 
             _consulConfigClientMock.Setup(ccc => ccc.GetConfig()).ThrowsAsync(new Exception());
             _consulConfigSourceMock
-                .SetupGet(ccs => ccs.OnLoadException)
+                .Setup(ccs => ccs.OnLoadException)
                 .Returns(exceptionContext =>
                 {
                     calledOnLoadException = true;
@@ -159,7 +159,7 @@ namespace Winton.Extensions.Configuration.Consul
 
             _consulConfigClientMock.Setup(ccc => ccc.GetConfig()).ThrowsAsync(expectedException);
             _consulConfigSourceMock
-                .SetupGet(ccs => ccs.OnLoadException)
+                .Setup(ccs => ccs.OnLoadException)
                 .Returns(exceptionContext =>
                 {
                     actualExceptionContext = exceptionContext;
@@ -183,7 +183,7 @@ namespace Winton.Extensions.Configuration.Consul
 
             _consulConfigClientMock.Setup(ccc => ccc.GetConfig()).ThrowsAsync(new Exception());
             _consulConfigSourceMock
-                .SetupGet(ccs => ccs.OnLoadException)
+                .Setup(ccs => ccs.OnLoadException)
                 .Returns(exceptionContext =>
                 {
                     actualExceptionContext = exceptionContext;
@@ -207,7 +207,7 @@ namespace Winton.Extensions.Configuration.Consul
 
             _consulConfigClientMock.Setup(ccc => ccc.GetConfig()).ThrowsAsync(exception);
             _consulConfigSourceMock
-                .SetupGet(ccs => ccs.OnLoadException)
+                .Setup(ccs => ccs.OnLoadException)
                 .Returns(exceptionContext =>
                 {
                     exceptionContext.Ignore = false;
@@ -223,7 +223,7 @@ namespace Winton.Extensions.Configuration.Consul
 
             _consulConfigClientMock.Setup(ccc => ccc.GetConfig()).ThrowsAsync(exception);
             _consulConfigSourceMock
-                .SetupGet(ccs => ccs.OnLoadException)
+                .Setup(ccs => ccs.OnLoadException)
                 .Returns(exceptionContext =>
                 {
                     exceptionContext.Ignore = true;
@@ -235,7 +235,7 @@ namespace Winton.Extensions.Configuration.Consul
         [Test]
         public void ShouldWatchForChangesIfSourceReloadOnChangesIsTrue()
         {
-            _consulConfigSourceMock.SetupGet(ccs => ccs.ReloadOnChange).Returns(true);
+            _consulConfigSourceMock.Setup(ccs => ccs.ReloadOnChange).Returns(true);
             _changeTokenMock
                 .Setup(ct => ct.RegisterChangeCallback(It.IsAny<Action<object>>(), It.IsAny<object>()))
                 .Returns(null as IDisposable);
@@ -252,8 +252,8 @@ namespace Winton.Extensions.Configuration.Consul
         public void ShouldReloadConfigIfReloadOnChangesAndDataInConsulHasChanged()
         {
             Action<object> onChangeAction = null;
-            _consulConfigSourceMock.SetupGet(ccs => ccs.ReloadOnChange).Returns(true);
-            _configQueryResultMock.SetupGet(cqr => cqr.Exists).Returns(false);
+            _consulConfigSourceMock.Setup(ccs => ccs.ReloadOnChange).Returns(true);
+            _configQueryResultMock.Setup(cqr => cqr.Exists).Returns(false);
             _changeTokenMock
                 .Setup(ct => ct.RegisterChangeCallback(It.IsAny<Action<object>>(), It.IsAny<object>()))
                 .Callback((Action<object> action, object state) =>
@@ -276,9 +276,9 @@ namespace Winton.Extensions.Configuration.Consul
         public void ShouldNotThrowIfDoesNotExistOnReload(bool optional)
         {
             Action<object> onChangeAction = null;
-            _consulConfigSourceMock.SetupGet(ccs => ccs.Optional).Returns(optional);
-            _consulConfigSourceMock.SetupGet(ccs => ccs.ReloadOnChange).Returns(true);
-            _configQueryResultMock.SetupGet(cqr => cqr.Exists).Returns(false);
+            _consulConfigSourceMock.Setup(ccs => ccs.Optional).Returns(optional);
+            _consulConfigSourceMock.Setup(ccs => ccs.ReloadOnChange).Returns(true);
+            _configQueryResultMock.Setup(cqr => cqr.Exists).Returns(false);
             _changeTokenMock
                 .Setup(ct => ct.RegisterChangeCallback(It.IsAny<Action<object>>(), It.IsAny<object>()))
                 .Callback((Action<object> action, object state) =>
@@ -301,9 +301,9 @@ namespace Winton.Extensions.Configuration.Consul
             var originalData = new Dictionary<string, string> { { key, value } };
             Action<object> onChangeAction = null;
 
-            _consulConfigSourceMock.SetupGet(ccs => ccs.Optional).Returns(false);
-            _consulConfigSourceMock.SetupGet(ccs => ccs.ReloadOnChange).Returns(true);
-            _configQueryResultMock.SetupGet(cqr => cqr.Exists).Returns(false);
+            _consulConfigSourceMock.Setup(ccs => ccs.Optional).Returns(false);
+            _consulConfigSourceMock.Setup(ccs => ccs.ReloadOnChange).Returns(true);
+            _configQueryResultMock.Setup(cqr => cqr.Exists).Returns(false);
             _changeTokenMock
                 .Setup(ct => ct.RegisterChangeCallback(It.IsAny<Action<object>>(), It.IsAny<object>()))
                 .Callback((Action<object> action, object state) =>
@@ -324,8 +324,8 @@ namespace Winton.Extensions.Configuration.Consul
         private void DoLoad(IDictionary<string, string> data)
         {
             _configParserMock.Setup(cp => cp.Parse(It.IsAny<MemoryStream>())).Returns(data);
-            _configQueryResultMock.SetupGet(cqr => cqr.Exists).Returns(true);
-            _configQueryResultMock.SetupGet(cqr => cqr.Value).Returns(new byte[] { });
+            _configQueryResultMock.Setup(cqr => cqr.Exists).Returns(true);
+            _configQueryResultMock.Setup(cqr => cqr.Value).Returns(new byte[] { });
 
             _consulConfigProvider.Load();
         }

--- a/test/Winton.Extensions.Configuration.Consul.Test/Winton.Extensions.Configuration.Consul.Test.csproj
+++ b/test/Winton.Extensions.Configuration.Consul.Test/Winton.Extensions.Configuration.Consul.Test.csproj
@@ -18,10 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Moq" Version="4.7.63" />
-    <PackageReference Include="NUnit" Version="3.7.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Moq" Version="4.8.1" />
+    <PackageReference Include="NUnit" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Bump versions of all dependencies to latest, except for `Microsoft.Extensions.Configuration` which is bumped to latest minor only as depending on 2.x.x would require targeting `netstandard2.0`.