### PR TITLE
Update dependencies.

### DIFF
--- a/src/Winton.Extensions.Configuration.Consul/Winton.Extensions.Configuration.Consul.csproj
+++ b/src/Winton.Extensions.Configuration.Consul/Winton.Extensions.Configuration.Consul.csproj
@@ -33,8 +33,7 @@
   <ItemGroup>
     <PackageReference Include="Consul" Version="0.7.2.4" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 

--- a/test/Website/Dockerfile
+++ b/test/Website/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/aspnetcore:2.0.5
+FROM microsoft/aspnetcore:2.0.6
 
 COPY bin/Release/netcoreapp2.0/publish /app
 WORKDIR /app

--- a/test/Website/Website.csproj
+++ b/test/Website/Website.csproj
@@ -17,7 +17,7 @@
     <Folder Include="wwwroot\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.6" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="2.2.0" />
   </ItemGroup>

--- a/test/Winton.Extensions.Configuration.Consul.Test/Winton.Extensions.Configuration.Consul.Test.csproj
+++ b/test/Winton.Extensions.Configuration.Consul.Test/Winton.Extensions.Configuration.Consul.Test.csproj
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.1.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
+    <PackageReference Include="FluentAssertions" Version="5.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
A final clean up task before doing a 2.0.0 release

* Patch update to `Microsoft.Extensions.Configuration` to 2.0.1
* Remove explicit dependency on `Newtonsoft.Json` and instead use version provided transitively from `Consul`.
* Update all test dependencies to latest. 