### PR TITLE
Create SimpleConfigurationParser implementation.

### DIFF
--- a/src/Winton.Extensions.Configuration.Consul/Parsers/Simple/SimpleConfigurationParser.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Parsers/Simple/SimpleConfigurationParser.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Winton. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENCE in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+
+namespace Winton.Extensions.Configuration.Consul.Parsers.Simple
+{
+    /// <inheritdoc />
+    /// <summary>
+    ///     Implemenation of <see cref="IConfigurationParser" /> for parsing simple values
+    /// </summary>
+    public sealed class SimpleConfigurationParser : IConfigurationParser
+    {
+        /// <inheritdoc />
+        public IDictionary<string, string> Parse(Stream stream)
+        {
+            using (var streamReader = new StreamReader(stream))
+            {
+                return new Dictionary<string, string> { { string.Empty, streamReader.ReadToEnd() } };
+            }
+        }
+    }
+}

--- a/test/Winton.Extensions.Configuration.Consul.Test/Parsers/Json/JsonConfigurationParserTests.cs
+++ b/test/Winton.Extensions.Configuration.Consul.Test/Parsers/Json/JsonConfigurationParserTests.cs
@@ -20,7 +20,7 @@ namespace Winton.Extensions.Configuration.Consul.Parsers.Json
             [Theory]
             [InlineData("{\"Key\": \"Value\"}", "Key", "Value")]
             [InlineData("{\"parent\": {\"child\": \"Value\"} }", "parent:child", "Value")]
-            public void ShouldParseSimpleJsonFromStream(string json, string key, string expectedValue)
+            private void ShouldParseSimpleJsonFromStream(string json, string key, string expectedValue)
             {
                 using (Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(json)))
                 {

--- a/test/Winton.Extensions.Configuration.Consul.Test/Parsers/Simple/SimpleConfigurationParserTests.cs
+++ b/test/Winton.Extensions.Configuration.Consul.Test/Parsers/Simple/SimpleConfigurationParserTests.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using FluentAssertions;
+using Xunit;
+
+namespace Winton.Extensions.Configuration.Consul.Parsers.Simple
+{
+    public class SimpleConfigurationParserTests
+    {
+        private readonly SimpleConfigurationParser _parser;
+
+        public SimpleConfigurationParserTests()
+        {
+            _parser = new SimpleConfigurationParser();
+        }
+
+        public sealed class Parse : SimpleConfigurationParserTests
+        {
+            [Fact]
+            private void ShouldParseSimpleValueFromStream()
+            {
+                using (Stream stream = new MemoryStream(Encoding.UTF8.GetBytes("value")))
+                {
+                    IDictionary<string, string> result = _parser.Parse(stream);
+
+                    result.Should().BeEquivalentTo(new Dictionary<string, string> { { string.Empty, "value" } });
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Addresses #36 
* Added `SimpleConfigurationParser` which just treats the value at a given key in Consul as a simple string value. In conjunction with #38, which added support for recursing keys in Consul, this allows clients to store their config as simple KV pairs in Consul rather than as a JSON value under a single node.