### PR TITLE
Added replacing '/' with ':' in the rootKey.

### DIFF
--- a/src/Winton.Extensions.Configuration.Consul/Extensions/KVPairExtensions.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Extensions/KVPairExtensions.cs
@@ -25,7 +25,7 @@ namespace Winton.Extensions.Configuration.Consul.Extensions
                         {
                             string key = $"{kvPair.Key.TrimEnd('/')}:{pair.Key}"
                                 .Replace('/', ':')
-                                .TrimStart(rootKey.ToCharArray())
+                                .TrimStart(rootKey.Replace('/', ':').ToCharArray())
                                 .TrimStart(':')
                                 .TrimEnd(':');
                             if (string.IsNullOrEmpty(key))

--- a/src/Winton.Extensions.Configuration.Consul/Extensions/KVPairExtensions.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Extensions/KVPairExtensions.cs
@@ -23,11 +23,9 @@ namespace Winton.Extensions.Configuration.Consul.Extensions
                     .Select(
                         pair =>
                         {
-                            string key = $"{kvPair.Key.TrimEnd('/')}:{pair.Key}"
+                            string key = $"{kvPair.Key.TrimStart(rootKey.ToCharArray()).TrimEnd('/')}:{pair.Key}"
                                 .Replace('/', ':')
-                                .TrimStart(rootKey.Replace('/', ':').ToCharArray())
-                                .TrimStart(':')
-                                .TrimEnd(':');
+                                .Trim(':');
                             if (string.IsNullOrEmpty(key))
                             {
                                 throw new InvalidKeyPairException(

--- a/test/Winton.Extensions.Configuration.Consul.Test/Extensions/KVPairExtensionsTests.cs
+++ b/test/Winton.Extensions.Configuration.Consul.Test/Extensions/KVPairExtensionsTests.cs
@@ -92,6 +92,36 @@ namespace Winton.Extensions.Configuration.Consul.Extensions
                         new KeyValuePair<string, string>("Section:SubSection:Property", "1"),
                         new KeyValuePair<string, string>("Section:SubSection:AnotherSubSection:Property", "2")
                     }
+                },
+                new object[]
+                {
+                    "path/to/rootKey",
+                    "path/to/rootKey",
+                    new Dictionary<string, string> { { "Key", "value" } },
+                    new[]
+                    {
+                        new KeyValuePair<string, string>("Key", "value")
+                    }
+                },
+                new object[]
+                {
+                    "path/to/rootKey",
+                    "path/to/rootKey/",
+                    new Dictionary<string, string> { { "Key", "value" } },
+                    new[]
+                    {
+                        new KeyValuePair<string, string>("Key", "value")
+                    }
+                },
+                new object[]
+                {
+                    "path/to/rootKey",
+                    "path/to/rootKey/Section",
+                    new Dictionary<string, string> { { "Key", "value" } },
+                    new[]
+                    {
+                        new KeyValuePair<string, string>("Section:Key", "value")
+                    }
                 }
             };
 


### PR DESCRIPTION
Fixed a bug when using rootKey that contains slashes in it. 

Example:
rootKey: `settings/production/myService`
value: 
```
{ "Foo": "bar" }
```

Expected configuration data:
```
"Foo": "bar"
```

Actual configuration data:
```
"production:myService:Foo": "bar"
```