### PR TITLE
Add an option to specify which section of key to remove

### DIFF
--- a/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationProvider.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationProvider.cs
@@ -71,9 +71,11 @@ namespace Winton.Extensions.Configuration.Consul
                     return;
                 }
 
+                string keyToRemove = _source.KeyToRemove ?? _source.Key;
+
                 Data = (result?.Response ?? new KVPair[0])
                     .Where(kvp => kvp.HasValue())
-                    .SelectMany(kvp => kvp.ConvertToConfig(_source.Key, _source.Parser))
+                    .SelectMany(kvp => kvp.ConvertToConfig(keyToRemove, _source.Parser))
                     .ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.OrdinalIgnoreCase);
             }
             catch (Exception exception)

--- a/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationSource.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationSource.cs
@@ -35,6 +35,8 @@ namespace Winton.Extensions.Configuration.Consul
 
         public string Key { get; }
 
+        public string KeyToRemove { get; set; }
+
         public Action<ConsulLoadExceptionContext> OnLoadException { get; set; }
 
         public Action<ConsulWatchExceptionContext> OnWatchException { get; set; }

--- a/src/Winton.Extensions.Configuration.Consul/Extensions/KVPairExtensions.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Extensions/KVPairExtensions.cs
@@ -13,7 +13,7 @@ namespace Winton.Extensions.Configuration.Consul.Extensions
     {
         internal static IEnumerable<KeyValuePair<string, string>> ConvertToConfig(
             this KVPair kvPair,
-            string rootKey,
+            string keyToRemove,
             IConfigurationParser parser)
         {
             using (Stream stream = new MemoryStream(kvPair.Value))
@@ -23,7 +23,7 @@ namespace Winton.Extensions.Configuration.Consul.Extensions
                     .Select(
                         pair =>
                         {
-                            string key = $"{kvPair.Key.RemoveStart(rootKey).TrimEnd('/')}:{pair.Key}"
+                            string key = $"{kvPair.Key.RemoveStart(keyToRemove).TrimEnd('/')}:{pair.Key}"
                                 .Replace('/', ':')
                                 .Trim(':');
                             if (string.IsNullOrEmpty(key))

--- a/src/Winton.Extensions.Configuration.Consul/IConsulConfigurationSource.cs
+++ b/src/Winton.Extensions.Configuration.Consul/IConsulConfigurationSource.cs
@@ -51,6 +51,14 @@ namespace Winton.Extensions.Configuration.Consul
         string Key { get; }
 
         /// <summary>
+        ///     Gets the portion of the Consul key to remove from the configuration keys.
+        ///     By default, when the configuration is parsed, the keys are created by removing the root key in Consul
+        ///     where the configuration is located.
+        ///     If this property is set then this string is removed instead of the Consul root key.
+        /// </summary>
+        string KeyToRemove { get; }
+
+        /// <summary>
         ///     Gets or sets an <see cref="Action" /> that is invoked when an exception is raised during config load.
         ///     Used by clients to handle the exception if possible and prevent it from being thrown.
         /// </summary>


### PR DESCRIPTION
Addresses #63 
* Add an option to allow clients to specify which section of the Consul key should be removed when parsing the config