### PR TITLE
Added backoffonerror to wait after an error occured

### DIFF
--- a/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationProvider.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationProvider.cs
@@ -31,7 +31,7 @@ namespace Winton.Extensions.Configuration.Consul
             if (source.ReloadOnChange)
             {
                 ChangeToken.OnChange(
-                    () => _consulConfigClient.Watch(_source.Key, _source.OnWatchException, _source.CancellationToken),
+                    () => _consulConfigClient.Watch(_source.Key, _source.BackoffOnError, _source.OnWatchException, _source.CancellationToken),
                     async () =>
                     {
                         await DoLoad(true).ConfigureAwait(false);

--- a/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationSource.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationSource.cs
@@ -47,6 +47,8 @@ namespace Winton.Extensions.Configuration.Consul
 
         public bool ReloadOnChange { get; set; } = false;
 
+        public TimeSpan? BackoffOnError { get; set; }
+
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         {
             var consulClientFactory = new ConsulClientFactory(this);

--- a/src/Winton.Extensions.Configuration.Consul/IConsulConfigurationClient.cs
+++ b/src/Winton.Extensions.Configuration.Consul/IConsulConfigurationClient.cs
@@ -20,11 +20,13 @@ namespace Winton.Extensions.Configuration.Consul
 
         /// <summary>Watches for config changes at a specified key.</summary>
         /// <param name="key">The key whose value should be watched for changes.</param>
+        /// <param name="backoffOnError">The time to wait after an error occured before retrying.</param>
         /// <param name="onException">An action to be invoked if an exception occurs during the watch.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
         /// <returns>An <see cref="IChangeToken" /> that will indicated when changes have occured.</returns>
         IChangeToken Watch(
             string key,
+            TimeSpan? backoffOnError,
             Action<ConsulWatchExceptionContext> onException,
             CancellationToken cancellationToken);
     }

--- a/src/Winton.Extensions.Configuration.Consul/IConsulConfigurationSource.cs
+++ b/src/Winton.Extensions.Configuration.Consul/IConsulConfigurationSource.cs
@@ -86,5 +86,10 @@ namespace Winton.Extensions.Configuration.Consul
         ///     Gets or sets a value indicating whether the source will be reloaded if the data in consul changes.
         /// </summary>
         bool ReloadOnChange { get; set; }
+
+        /// <summary>
+        ///     Gets or sets a value indicating how long to wait after an error, before retrying to fetch Consul changes
+        /// </summary>
+        TimeSpan? BackoffOnError { get; set; }
     }
 }

--- a/test/Winton.Extensions.Configuration.Consul.Test/ConsulConfigurationClientTests.cs
+++ b/test/Winton.Extensions.Configuration.Consul.Test/ConsulConfigurationClientTests.cs
@@ -115,7 +115,7 @@ namespace Winton.Extensions.Configuration.Consul
                     .Returns(getKvTaskSource.Task);
 
                 ChangeToken.OnChange(
-                    () => _consulConfigurationClient.Watch("Test", null, default(CancellationToken)),
+                    () => _consulConfigurationClient.Watch("Test", null, null, default(CancellationToken)),
                     () => configChangedCompletion.SetResult(true));
 
                 getKvTaskSource.SetResult(
@@ -143,6 +143,7 @@ namespace Winton.Extensions.Configuration.Consul
 
                 _consulConfigurationClient.Watch(
                     "Test",
+                    null,
                     exceptionContext =>
                     {
                         actualException = exceptionContext.Exception;
@@ -171,6 +172,7 @@ namespace Winton.Extensions.Configuration.Consul
                 _consulConfigurationClient
                     .Watch(
                         "Test",
+                        null,
                         exceptionContext =>
                         {
                             watchCompletion.SetResult(false);
@@ -237,7 +239,7 @@ namespace Winton.Extensions.Configuration.Consul
                 // Calling it a second time should invoke a long polling with the index from the previous get call
                 var watchCompletion = new TaskCompletionSource<bool>();
                 _consulConfigurationClient
-                    .Watch("Test", null, default(CancellationToken))
+                    .Watch("Test", null, null, default(CancellationToken))
                     .RegisterChangeCallback(o => watchCompletion.SetResult(true), new object());
 
                 watchKvTaskSource.SetResult(
@@ -272,7 +274,7 @@ namespace Winton.Extensions.Configuration.Consul
                 // The KV result initiated by the first watch returns with an updated index of 1
                 var watchCompletion1 = new TaskCompletionSource<bool>();
                 _consulConfigurationClient
-                    .Watch("Test", null, default(CancellationToken))
+                    .Watch("Test", null, null, default(CancellationToken))
                     .RegisterChangeCallback(o => watchCompletion1.SetResult(true), new object());
 
                 watchKvTaskSource1.SetResult(
@@ -286,7 +288,7 @@ namespace Winton.Extensions.Configuration.Consul
                 // The KV result from the second watch returns with an updated index so that it can be determined that it ran inside the watch
                 var watchCompletion2 = new TaskCompletionSource<bool>();
                 _consulConfigurationClient
-                    .Watch("Test", null, default(CancellationToken))
+                    .Watch("Test", null, null, default(CancellationToken))
                     .RegisterChangeCallback(o => watchCompletion2.SetResult(true), new object());
 
                 watchKvTaskSource2.SetResult(

--- a/test/Winton.Extensions.Configuration.Consul.Test/ConsulConfigurationProviderTests.cs
+++ b/test/Winton.Extensions.Configuration.Consul.Test/ConsulConfigurationProviderTests.cs
@@ -260,6 +260,7 @@ namespace Winton.Extensions.Configuration.Consul
                         ccc =>
                             ccc.Watch(
                                 "Test",
+                                null,
                                 It.IsAny<Action<ConsulWatchExceptionContext>>(),
                                 default(CancellationToken)))
                     .Returns(_firstChangeToken)
@@ -331,7 +332,7 @@ namespace Winton.Extensions.Configuration.Consul
                 Action verifying =
                     () =>
                         _consulConfigClientMock.Verify(
-                            ccs => ccs.Watch("Test", _source.OnWatchException, default(CancellationToken)),
+                            ccs => ccs.Watch("Test", null, _source.OnWatchException, default(CancellationToken)),
                             Times.Once);
                 verifying.Should().NotThrow();
             }


### PR DESCRIPTION
Relates to #70, adding a `backoffonerror` to wait after an error occurs on consul watch. 