### PR TITLE
 Use the recommended approach for preserving exceptions when calling async code synchronously

### DIFF
--- a/Winton.Extensions.Configuration.Consul.sln.DotSettings
+++ b/Winton.Extensions.Configuration.Consul.sln.DotSettings
@@ -464,6 +464,7 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>

--- a/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationProvider.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationProvider.cs
@@ -42,19 +42,7 @@ namespace Winton.Extensions.Configuration.Consul
 
         public override void Load()
         {
-            try
-            {
-                DoLoad(false).Wait();
-            }
-            catch (AggregateException aggregateException)
-            {
-                if (aggregateException.InnerException != null)
-                {
-                    throw aggregateException.InnerException;
-                }
-
-                throw;
-            }
+            DoLoad(false).GetAwaiter().GetResult();
         }
 
         private async Task DoLoad(bool reloading)


### PR DESCRIPTION
While looking into async support for configuration providers, I came across [this issue](https://github.com/aspnet/Extensions/issues/802).

One [comment](https://github.com/aspnet/Extensions/issues/802#issuecomment-451150122) mentioned the suggested practice for preserving exceptions in [this issue](https://github.com/aspnet/Security/issues/59). So I decided to make this enhancement, which saves a few lines of code here.

As part of this work, I had to fix/ignore some compiler warnings, which I have done in a separate commit.