### PR TITLE
Update to Microsoft.Extensions.Configuration version 3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ matrix:
     - os: linux
       dist: xenial
       sudo: required
-      dotnet: 2.2
+      dotnet: 3.0
     - os: osx 
-      osx_image: xcode9 # OSX 10.12
-      dotnet: 2.2.104
+      osx_image: xcode11.2
+      dotnet: 3.0.100
       before_install:
         - ulimit -n 4096
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,12 +3,12 @@ environment:
   CLI_VERSION: latest
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
-image: Visual Studio 2017
+image: Visual Studio 2019
 configuration:
     - Release
 skip_tags: true
 before_build:
-    - dotnet tool install -g GitVersion.Tool --version 4.0.1-beta1-58
+    - dotnet tool install -g GitVersion.Tool
     - dotnet gitversion /l console /output buildserver
 build_script:
     - dotnet build -c Release -p:Version=%GitVersion_NuGetVersion%

--- a/build.sh
+++ b/build.sh
@@ -5,8 +5,8 @@ set -e
 # Build
 dotnet restore
 dotnet build src/Winton.Extensions.Configuration.Consul -c Release -f netstandard2.0 --no-restore
-dotnet build test/Winton.Extensions.Configuration.Consul.Test -c Release -f netcoreapp2.2 --no-restore
-dotnet build test/Website -c Release -f netcoreapp2.2 --no-restore
+dotnet build test/Winton.Extensions.Configuration.Consul.Test -c Release -f netcoreapp3.0 --no-restore
+dotnet build test/Website -c Release -f netcoreapp3.0 --no-restore
 
 # Unit Test
 dotnet test -c Release --no-build

--- a/src/Winton.Extensions.Configuration.Consul/ConfigurationBuilderExtensions.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConfigurationBuilderExtensions.cs
@@ -23,7 +23,7 @@ namespace Winton.Extensions.Configuration.Consul
         ///     The <see cref="CancellationToken" /> used to cancel any open Consul connections or
         ///     watchers.
         /// </param>
-        /// <returns>The builder</returns>
+        /// <returns>The builder.</returns>
         public static IConfigurationBuilder AddConsul(
             this IConfigurationBuilder builder,
             string key,
@@ -36,14 +36,14 @@ namespace Winton.Extensions.Configuration.Consul
         ///     Adds Consul as a configuration source to the <see cref="IConfigurationBuilder" />
         ///     and applies the given overrides to the <see cref="IConsulConfigurationSource" />.
         /// </summary>
-        /// <param name="builder">The builder to add consul to</param>
-        /// <param name="key">The key in consul where the configuration is located</param>
+        /// <param name="builder">The builder to add consul to.</param>
+        /// <param name="key">The key in consul where the configuration is located.</param>
         /// <param name="cancellationToken">
         ///     The <see cref="CancellationToken" /> used to cancel any open Consul connections or
         ///     watchers.
         /// </param>
-        /// <param name="options">An action used to configure the options of the <see cref="IConsulConfigurationSource" /></param>
-        /// <returns>The builder</returns>
+        /// <param name="options">An action used to configure the options of the <see cref="IConsulConfigurationSource" />.</param>
+        /// <returns>The builder.</returns>
         public static IConfigurationBuilder AddConsul(
             this IConfigurationBuilder builder,
             string key,

--- a/src/Winton.Extensions.Configuration.Consul/IConsulConfigurationSource.cs
+++ b/src/Winton.Extensions.Configuration.Consul/IConsulConfigurationSource.cs
@@ -13,7 +13,7 @@ namespace Winton.Extensions.Configuration.Consul
 {
     /// <inheritdoc />
     /// <summary>
-    ///     An <see cref="IConfigurationSource" /> for the ConsulConfigurationProvider
+    ///     An <see cref="IConfigurationSource" /> for the ConsulConfigurationProvider.
     /// </summary>
     public interface IConsulConfigurationSource : IConfigurationSource
     {

--- a/src/Winton.Extensions.Configuration.Consul/Parsers/Json/JsonConfigurationParser.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Parsers/Json/JsonConfigurationParser.cs
@@ -10,7 +10,7 @@ namespace Winton.Extensions.Configuration.Consul.Parsers.Json
 {
     /// <inheritdoc />
     /// <summary>
-    ///     Implemenation of <see cref="IConfigurationParser" /> for parsing JSON Configuration
+    ///     Implementation of <see cref="IConfigurationParser" /> for parsing JSON Configuration.
     /// </summary>
     public sealed class JsonConfigurationParser : IConfigurationParser
     {

--- a/src/Winton.Extensions.Configuration.Consul/Parsers/Simple/SimpleConfigurationParser.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Parsers/Simple/SimpleConfigurationParser.cs
@@ -8,7 +8,7 @@ namespace Winton.Extensions.Configuration.Consul.Parsers.Simple
 {
     /// <inheritdoc />
     /// <summary>
-    ///     Implemenation of <see cref="IConfigurationParser" /> for parsing simple values
+    ///     Implementation of <see cref="IConfigurationParser" /> for parsing simple values.
     /// </summary>
     public sealed class SimpleConfigurationParser : IConfigurationParser
     {

--- a/src/Winton.Extensions.Configuration.Consul/Winton.Extensions.Configuration.Consul.csproj
+++ b/src/Winton.Extensions.Configuration.Consul/Winton.Extensions.Configuration.Consul.csproj
@@ -31,8 +31,8 @@
 
   <ItemGroup>
     <PackageReference Include="Consul" Version="0.7.2.6" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.2" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">

--- a/stylecop.json
+++ b/stylecop.json
@@ -1,25 +1,23 @@
 {
-    "$schema":
-        "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/1.0.2/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
-    "settings": {
-        "documentationRules": {
-            "companyName": "Winton",
-            "copyrightText":
-                "Copyright (c) {companyName}. All rights reserved.\nLicensed under the Apache License, Version 2.0. See LICENCE in the project root for license information.",
-            "documentInternalElements": false,
-            "xmlHeader": false
-        },
-        "maintainabilityRules": {
-            "topLevelTypes": [
-                "class",
-                "enum",
-                "interface",
-                "struct"
-            ]
-        },
-        "orderingRules": {
-            "blankLinesBetweenUsingGroups": "omit",
-            "usingDirectivesPlacement": "outsideNamespace"
-        }
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/1.1.118/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "companyName": "Winton",
+      "copyrightText": "Copyright (c) {companyName}. All rights reserved.\nLicensed under the Apache License, Version 2.0. See LICENCE in the project root for license information.",
+      "documentInternalElements": false,
+      "xmlHeader": false
+    },
+    "maintainabilityRules": {
+      "topLevelTypes": [
+        "class",
+        "enum",
+        "interface",
+        "struct"
+      ]
+    },
+    "orderingRules": {
+      "blankLinesBetweenUsingGroups": "omit",
+      "usingDirectivesPlacement": "outsideNamespace"
     }
+  }
 }

--- a/test/Website/Controllers/ConfigController.cs
+++ b/test/Website/Controllers/ConfigController.cs
@@ -3,20 +3,21 @@ using Microsoft.Extensions.Configuration;
 
 namespace Winton.Extensions.Configuration.Consul.Website.Controllers
 {
+    [ApiController]
     [Route("[controller]")]
-    public sealed class ConfigController : Controller
+    public sealed class ConfigController : ControllerBase
     {
-        private readonly IConfiguration _configurationRoot;
+        private readonly IConfiguration _configuration;
 
         public ConfigController(IConfiguration configuration)
         {
-            _configurationRoot = configuration;
+            _configuration = configuration;
         }
 
         [HttpGet("{key}")]
         public IActionResult GetValueForKey(string key)
         {
-            return Json(_configurationRoot[key]);
+            return Ok(_configuration[key]);
         }
     }
 }

--- a/test/Website/Dockerfile
+++ b/test/Website/Dockerfile
@@ -1,6 +1,6 @@
-FROM microsoft/dotnet:2.2-aspnetcore-runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.0
 
-COPY bin/Release/netcoreapp2.2/publish /app
+COPY bin/Release/netcoreapp3.0/publish /app
 WORKDIR /app
  
 EXPOSE 80/tcp

--- a/test/Website/IntegrationTests/set-config.sh
+++ b/test/Website/IntegrationTests/set-config.sh
@@ -1,1 +1,3 @@
-curl -X PUT --header "Content-Type:application/json" -d @appsettings.json http://consul:8500/v1/kv/appsettings.json
+#! /bin/bash
+
+curl -v -X PUT --header "Content-Type:application/json" -d @appsettings.json http://consul:8500/v1/kv/appsettings.json

--- a/test/Website/IntegrationTests/test.sh
+++ b/test/Website/IntegrationTests/test.sh
@@ -1,4 +1,10 @@
+#! /bin/bash
+
 ./set-config.sh
+
+# Sleep for 10 seconds to allow the app to sync the config
+sleep 10
+
 for TEST in ./tests/*
 	do
 		if [ -f $TEST -a -x $TEST ]

--- a/test/Website/IntegrationTests/tests/should-get-int-value-from-consul.sh
+++ b/test/Website/IntegrationTests/tests/should-get-int-value-from-consul.sh
@@ -1,4 +1,6 @@
-if curl -X GET --header "Content-Type:application/json" http://website:5000/config/integer | grep -q '13'; then
+#! /bin/bash
+
+if curl -X GET --header "Accept:application/json" http://website:5000/config/integer | grep -q '13'; then
   echo `basename "$0"` " passed!"
   exit 0
 else

--- a/test/Website/IntegrationTests/tests/should-get-string-value-from-consul.sh
+++ b/test/Website/IntegrationTests/tests/should-get-string-value-from-consul.sh
@@ -1,4 +1,6 @@
-if curl -X GET --header "Content-Type:application/json" http://website:5000/config/string | grep -q 'Hello'; then
+#! /bin/bash
+
+if curl -X GET --header "Accept:application/json" http://website:5000/config/string | grep -q 'Hello'; then
   echo `basename "$0"` "passed!"
   exit 0
 else

--- a/test/Website/Startup.cs
+++ b/test/Website/Startup.cs
@@ -1,8 +1,7 @@
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Swashbuckle.AspNetCore.Swagger;
+using Microsoft.OpenApi.Models;
 
 namespace Winton.Extensions.Configuration.Consul.Website
 {
@@ -28,16 +27,17 @@ namespace Winton.Extensions.Configuration.Consul.Website
                         c.SwaggerEndpoint($"swagger/{_Version}/swagger.json", _AppTitle);
                         c.RoutePrefix = string.Empty;
                     })
-                .UseMvc();
+                .UseRouting()
+                .UseEndpoints(options => options.MapControllers());
         }
 
         public void ConfigureServices(IServiceCollection services)
         {
             services
-                .AddSwaggerGen(c => { c.SwaggerDoc(_Version, new Info { Title = _AppTitle, Version = _Version }); })
+                .AddSwaggerGen(
+                    c => { c.SwaggerDoc(_Version, new OpenApiInfo { Title = _AppTitle, Version = _Version }); })
                 .AddSingleton(_configuration)
-                .AddMvc()
-                .SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+                .AddControllers();
         }
     }
 }

--- a/test/Website/Website.csproj
+++ b/test/Website/Website.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <AssemblyName>Winton.Extensions.Configuration.Consul.Test.Website</AssemblyName>
     <GenerateDocumentationFile>False</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);SA0001;SA1101;SA1309;SA1413;SA1600;SA1633;SA1652</NoWarn>
     <RootNamespace>Winton.Extensions.Configuration.Consul.Website</RootNamespace>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
 
@@ -18,9 +17,8 @@
     <Folder Include="wwwroot\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Winton.Extensions.Configuration.Consul\Winton.Extensions.Configuration.Consul.csproj" />

--- a/test/Winton.Extensions.Configuration.Consul.Test/Winton.Extensions.Configuration.Consul.Test.csproj
+++ b/test/Winton.Extensions.Configuration.Consul.Test/Winton.Extensions.Configuration.Consul.Test.csproj
@@ -5,7 +5,7 @@
     <IsPackable>False</IsPackable>
     <NoWarn>$(NoWarn);SA0001;SA1101;SA1118;SA1309;SA1413;SA1600;SA1633;SA1652</NoWarn>
     <RootNamespace>Winton.Extensions.Configuration.Consul</RootNamespace>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
   
@@ -18,10 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Moq" Version="4.13.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>


### PR DESCRIPTION
* Updates the `Microsoft.Extensions.Configuration` dependency to version 3.
* Updates the test projects to `netcoreapp3.0`.
* As this library tracks the major version of `Microsoft.Extensions.Configuration` this will cause a breaking change.
* There is a potential question to be addressed here as to whether we should use the new `System.Text.Json` instead of `Newtonsoft.Json`. The `Consul` dependency brings `NewtonSoft.Json` in anyway, so we already have access to that dependency transitively, but on the other hand the [`JsonConfigurationProvider`](https://github.com/aspnet/Extensions/blob/master/src/Configuration/Config.Json/src/JsonConfigurationFileParser.cs) has moved to using `System.Text.Json`.