### PR TITLE
Added .ContinueWith on Task.Delay to surpress exceptions thrown during Dispose

### DIFF
--- a/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationProvider.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationProvider.cs
@@ -143,7 +143,8 @@ namespace Winton.Extensions.Configuration.Consul
                         _source.OnWatchException?.Invoke(
                             new ConsulWatchExceptionContext(exception, ++consecutiveFailureCount, _source)) ??
                         TimeSpan.FromSeconds(5);
-                    await Task.Delay(wait, _cancellationTokenSource.Token);
+                    await Task.Delay(wait, _cancellationTokenSource.Token)
+                        .ContinueWith(_ => { }); // suppress cancellation exceptions
                 }
             }
         }

--- a/test/Winton.Extensions.Configuration.Consul.Test/ConsulConfigurationProviderTests.cs
+++ b/test/Winton.Extensions.Configuration.Consul.Test/ConsulConfigurationProviderTests.cs
@@ -94,11 +94,9 @@ namespace Winton.Extensions.Configuration.Consul
                         })
                     .Returns<string, QueryOptions, CancellationToken>(
                         (_, __, token) =>
-                        {
-                            return token.IsCancellationRequested
+                            token.IsCancellationRequested
                                 ? Task.FromCanceled<QueryResult<KVPair[]>>(token)
-                                : Task.Delay(5).ContinueWith(t => new QueryResult<KVPair[]> { StatusCode = HttpStatusCode.OK });
-                        });
+                                : Task.Delay(5).ContinueWith(t => new QueryResult<KVPair[]> { StatusCode = HttpStatusCode.OK }));
 
                 _provider.Load();
 


### PR DESCRIPTION
Fixes issue #91

While I admit it is not the most expressive way of dealing with TaskCancellationExceptions (hence the comment), it is a common way of doing it.