### PR TITLE
Made ConsulConfigurationProvider.Dispose idempotent and thread safe

### DIFF
--- a/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationProvider.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationProvider.cs
@@ -27,6 +27,7 @@ namespace Winton.Extensions.Configuration.Consul
         private readonly IConsulConfigurationSource _source;
         private ulong _lastIndex;
         private Task? _pollTask;
+        private bool _disposed;
 
         public ConsulConfigurationProvider(
             IConsulConfigurationSource source,
@@ -44,8 +45,17 @@ namespace Winton.Extensions.Configuration.Consul
 
         public void Dispose()
         {
-            _cancellationTokenSource.Cancel();
-            _cancellationTokenSource.Dispose();
+            lock (this)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _cancellationTokenSource.Cancel();
+                _cancellationTokenSource.Dispose();
+                _disposed = true;
+            }
         }
 
         public override void Load()

--- a/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationProvider.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationProvider.cs
@@ -45,17 +45,14 @@ namespace Winton.Extensions.Configuration.Consul
 
         public void Dispose()
         {
-            lock (this)
+            if (_disposed)
             {
-                if (_disposed)
-                {
-                    return;
-                }
-
-                _cancellationTokenSource.Cancel();
-                _cancellationTokenSource.Dispose();
-                _disposed = true;
+                return;
             }
+
+            _cancellationTokenSource.Cancel();
+            _cancellationTokenSource.Dispose();
+            _disposed = true;
         }
 
         public override void Load()

--- a/test/Winton.Extensions.Configuration.Consul.Test/ConsulConfigurationProviderTests.cs
+++ b/test/Winton.Extensions.Configuration.Consul.Test/ConsulConfigurationProviderTests.cs
@@ -112,6 +112,23 @@ namespace Winton.Extensions.Configuration.Consul
                     kv => kv.List("Test", It.IsAny<QueryOptions>(), It.IsAny<CancellationToken>()),
                     Times.Between(expectedKvCalls, expectedKvCalls + 1, Range.Inclusive));
             }
+
+            [Fact]
+            private void ShouldNotThrowOnMultipleDisposeCalls()
+            {
+                _source.ReloadOnChange = true;
+                _source.Optional = true;
+                _kvEndpoint
+                    .Setup(kv => kv.List("Test", It.IsAny<QueryOptions>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new QueryResult<KVPair[]> { StatusCode = HttpStatusCode.OK });
+
+                _provider.Load();
+                _provider.Dispose();
+
+                var disposeException = Record.Exception(() => _provider.Dispose());
+
+                Assert.Null(disposeException);
+            }
         }
 
         public sealed class DoNotReloadOnChange : ConsulConfigurationProviderTests

--- a/test/Winton.Extensions.Configuration.Consul.Test/ConsulConfigurationProviderTests.cs
+++ b/test/Winton.Extensions.Configuration.Consul.Test/ConsulConfigurationProviderTests.cs
@@ -125,9 +125,9 @@ namespace Winton.Extensions.Configuration.Consul
                 _provider.Load();
                 _provider.Dispose();
 
-                var disposeException = Record.Exception(() => _provider.Dispose());
+                var secondDispose = _provider.Invoking(p => p.Dispose());
 
-                Assert.Null(disposeException);
+                secondDispose.Should().NotThrow();
             }
         }
 


### PR DESCRIPTION
While the changes in #93 have fixed the issue reported in #91, an exception is still thrown if `Dispose()` is called more than once.

[According to Microsoft](https://docs.microsoft.com/en-us/dotnet/api/system.idisposable.dispose?redirectedfrom=MSDN&view=netframework-4.8#remarks) it should be safe to call `Dispose()` multiple times, without any exceptions being thrown:

> If an object's Dispose method is called more than once, the object must ignore all calls after the first one. The object must not throw an exception if its Dispose method is called multiple times.

A try/catch block around the Dispose implementation would prevent any exceptions being thrown, but I will leave it up for discussion as to whether or not that should be added.

Furthermore, I've wrapped the implementation in a lock statement for thread safety. It seems people disagree on whether this is necessary (why are multiple threads trying to dispose the object concurrently?) but on the other hand, why wouldn't you add that extra safety for the people using your NuGet package?

Let me know what you think.