### PR TITLE
Support opt-in parsing of keys as well as value streams

### DIFF
--- a/src/Winton.Extensions.Configuration.Consul/Extensions/KVPairExtensions.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Extensions/KVPairExtensions.cs
@@ -31,7 +31,13 @@ namespace Winton.Extensions.Configuration.Consul.Extensions
                                 "The key must not be null or empty. Ensure that there is at least one key under the root of the config or that the data there contains more than just a single value.");
                         }
 
-                        return new KeyValuePair<string, string>(key, pair.Value);
+                        var configPair = new KeyValuePair<string, string>(key, pair.Value);
+                        if (parser is IConfigurationKeyValueRewriter rewriter)
+                        {
+                            configPair = rewriter.Rewrite(configPair);
+                        }
+
+                        return configPair;
                     });
         }
 

--- a/src/Winton.Extensions.Configuration.Consul/Parsers/IConfigurationKeyValueRewriter.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Parsers/IConfigurationKeyValueRewriter.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Winton. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Winton.Extensions.Configuration.Consul.Parsers
+{
+    /// <summary>
+    ///     Allows clients to rewrite configuration keys as they are parsed.
+    /// </summary>
+    public interface IConfigurationKeyValueRewriter
+    {
+        /// <summary>
+        ///     Rewrites a configuration KeyValuePair.
+        /// </summary>
+        /// <param name="pair">The source <see cref="KeyValuePair{TKey, TValue}"/> pair read from Consul.</param>
+        /// <returns>The rewritten <see cref="KeyValuePair{TKey, TValue}"/>.</returns>
+        KeyValuePair<string, string> Rewrite(KeyValuePair<string, string> pair);
+    }
+}

--- a/src/Winton.Extensions.Configuration.Consul/Parsers/JsonConfigurationParser.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Parsers/JsonConfigurationParser.cs
@@ -12,7 +12,7 @@ namespace Winton.Extensions.Configuration.Consul.Parsers
     /// <summary>
     ///     Implementation of <see cref="IConfigurationParser" /> for parsing JSON Configuration.
     /// </summary>
-    public sealed class JsonConfigurationParser : IConfigurationParser
+    public class JsonConfigurationParser : IConfigurationParser
     {
         /// <inheritdoc />
         public IDictionary<string, string> Parse(Stream stream)

--- a/src/Winton.Extensions.Configuration.Consul/Parsers/SimpleConfigurationParser.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Parsers/SimpleConfigurationParser.cs
@@ -10,7 +10,7 @@ namespace Winton.Extensions.Configuration.Consul.Parsers
     /// <summary>
     ///     Implementation of <see cref="IConfigurationParser" /> for parsing simple values.
     /// </summary>
-    public sealed class SimpleConfigurationParser : IConfigurationParser
+    public class SimpleConfigurationParser : IConfigurationParser
     {
         /// <inheritdoc />
         public IDictionary<string, string> Parse(Stream stream)


### PR DESCRIPTION
based on discussion in https://github.com/wintoncode/Winton.Extensions.Configuration.Consul/issues/101 it seems that enabling this feature now via a new marker interface allowing clients to opt-in to this behavior may be a good short-term strategy, while introducing a breaking change to the `IConfigurationPaser` contract or changing target platforms to support c# 8 Default Interface Implementations may be preferred at a future point when this library is shipping other breaking changes.

this branch introduces a new marker interface which supports rewriting the `KeyValuePair<string,string>` configuration pair after it's been parsed by the existing `Parse(stream)` method and before it's had any prefix (such as the root key) stripped away:
```csharp
    /// <summary>
    ///     Allows clients to rewrite configuration keys as they are parsed.
    /// </summary>
    public interface IConfigurationKeyValueRewriter
    {
        /// <summary>
        ///     Rewrites a configuration KeyValuePair.
        /// </summary>
        /// <param name="pair">The source <see cref="KeyValuePair{TKey, TValue}"/> pair read from Consul.</param>
        /// <returns>The rewritten <see cref="KeyValuePair{TKey, TValue}"/>.</returns>
        KeyValuePair<string, string> Rewrite(KeyValuePair<string, string> pair);
    }
```

to use this new interface you:
- create a custom parser class
    - you can create your own and implement `IConfigurationParser.Parse(...)` or you can derive from `SimpleConfigurationParser` or `JsonConfigurationParser`
- add this new `IConfigurationKeyValueRewriter` interface to your parser so that the one parser class fills both `IConfigurationParser` and `IConfigurationKeyValueRewriter`
- when the `ConsulConfigurationProvider` reads values from consul, it will invoke your custom parser's `Rewrite(...)` method after the `Parse(...)` method and before any prefix is removed (so in `Rewrite(...)` you get the full consul key)

and example implementation is in [the unit tests in this PR](https://github.com/wintoncode/Winton.Extensions.Configuration.Consul/compare/master...davidalpert:parse-with-key-non-breaking?expand=1#diff-d61fdcf76d6f59585ae1dffb3e211f75R286-R292)
```csharp
            public class SimpleRewritingConfigurationParser : SimpleConfigurationParser, IConfigurationKeyValueRewriter
            {
                public KeyValuePair<string, string> Rewrite(KeyValuePair<string, string> pair)
                {
                    return new KeyValuePair<string, string>(pair.Key.Replace("__", ":"), pair.Value);
                }
            }
```

this `SimpleRewritingConfigurationParser` example extends the `SimpleConfigurationParser` strategy with the added functionality of rewriting two consecutive underscores (`__`) with a colon (`:`), emulating that feature from the default Environment provider.

Addresses #101 