### PR TITLE
refactor out a Func<KVPair, IEnumerable<KeyValuePair<string,string>>>

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Adds support for configuring .NET Core applications using Consul. Works great wi
     - [Consul values are JSON](#consul-values-are-json)
     - [Consul values are scalars](#consul-values-are-scalars)
     - [Consul values are a mix of JSON and scalars](#consul-values-are-a-mix-of-json-and-scalars)
-    - [Customizing the `ConvertToConfig` strategy](#customizing-the-converttoconfig-strategy)
+    - [Customizing the `ConvertConsulKVPairToConfig` strategy](#customizing-the-ConvertConsulKVPairToConfig-strategy)
 
 ## Installation
 
@@ -80,14 +80,14 @@ Assuming the application is running in the 'Development' environment and the app
    A `bool` indicating whether to reload the config when it changes in Consul.
    If `true` it will watch the configured key for changes. When a change occurs the config will be asynchronously reloaded and the `IChangeToken` will be triggered to signal that the config has been reloaded. Defaults to `false`.
 
-* **`ConvertToConfig`**
+* **`ConvertConsulKVPairToConfig`**
 
    A `Func<KVPair, IEnumerable<KeyValuePair<string, string>>>` which gives you complete control over the parsing of fully qualified consul keys and raw consul values; the default implementation will:
 
    - Use the configured `Parser` to parse consul values
    - Remove the configured `KeyToRemove` prefix from consul keys
 
-   When setting this member, however, you bypass the default key and value processing and `Parser` and `KeyToRemove` have no effect unless your `ConvertToConfig` function uses them.
+   When setting this member, however, you bypass the default key and value processing and `Parser` and `KeyToRemove` have no effect unless your `ConvertConsulKVPairToConfig` function uses them.
 
 ## Configure Parsing Options
 
@@ -173,9 +173,9 @@ builder
     .AddConsul("myApp/jsonValues", cancellationToken);
 ```
 
-### Customizing the `ConvertToConfig` strategy
+### Customizing the `ConvertConsulKVPairToConfig` strategy
 
-Sometimes you may need more control over the conversion of raw consul KV pairs into `IConfiguration` data.  In this case you can set a custom `ConvertToConfig` function:
+Sometimes you may need more control over the conversion of raw consul KV pairs into `IConfiguration` data.  In this case you can set a custom `ConvertConsulKVPairToConfig` function:
 
 ```csharp
 builder
@@ -183,10 +183,10 @@ builder
         "myApp",
         options =>
         {
-            options.ConvertToConfig = kvPair =>
+            options.ConvertConsulKVPairToConfig = kvPair =>
             {
                 var normalizedKey = kvPair.Key
-                    .Replace(_source.KeyToRemove, string.Empty)
+                    .Replace("base/key", string.Empty)
                     .Replace("__", "/")
                     .Replace("/", ":")
                     .Trim('/');
@@ -203,4 +203,4 @@ builder
         });
 ```
 
-> :warning: Caution: by customizing this `ConvertToConfig` strategy you bypass any automatic invocation of the configured `Parser` and `KeyToRemove` so it becomes your responsibility to use them as needed by your scenario.
+> :warning: Caution: by customizing this `ConvertConsulKVPairToConfig` strategy you bypass any automatic invocation of the configured `Parser` and `KeyToRemove` so it becomes your responsibility to use them as needed by your scenario.

--- a/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationProvider.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationProvider.cs
@@ -156,7 +156,7 @@ namespace Winton.Extensions.Configuration.Consul
 
         private void SetData(QueryResult<KVPair[]> result)
         {
-            Data = result.ToConfigDictionary(_source.KeyToRemove, _source.Parser);
+            Data = result.ToConfigDictionary(_source.ConvertToConfig);
         }
 
         private void SetLastIndex(QueryResult result)

--- a/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationProvider.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationProvider.cs
@@ -156,7 +156,7 @@ namespace Winton.Extensions.Configuration.Consul
 
         private void SetData(QueryResult<KVPair[]> result)
         {
-            Data = result.ToConfigDictionary(_source.ConvertToConfig);
+            Data = result.ToConfigDictionary(_source.ConvertConsulKVPairToConfig);
         }
 
         private void SetLastIndex(QueryResult result)

--- a/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationSource.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationSource.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using Consul;
 using Microsoft.Extensions.Configuration;
+using Winton.Extensions.Configuration.Consul.Extensions;
 using Winton.Extensions.Configuration.Consul.Parsers;
 
 namespace Winton.Extensions.Configuration.Consul
@@ -22,6 +24,7 @@ namespace Winton.Extensions.Configuration.Consul
 
             Key = key;
             Parser = new JsonConfigurationParser();
+            ConvertToConfig = DefaultConvertToConfigStrategy;
         }
 
         public Action<ConsulClientConfiguration>? ConsulConfigurationOptions { get; set; }
@@ -37,6 +40,8 @@ namespace Winton.Extensions.Configuration.Consul
             get => _keyToRemove ?? Key;
             set => _keyToRemove = value;
         }
+
+        public Func<KVPair, IEnumerable<KeyValuePair<string, string>>> ConvertToConfig { get; set; }
 
         public Action<ConsulLoadExceptionContext>? OnLoadException { get; set; }
 
@@ -54,6 +59,11 @@ namespace Winton.Extensions.Configuration.Consul
         {
             var consulClientFactory = new ConsulClientFactory(this);
             return new ConsulConfigurationProvider(this, consulClientFactory);
+        }
+
+        private IEnumerable<KeyValuePair<string, string>> DefaultConvertToConfigStrategy(KVPair consulKvPair)
+        {
+            return consulKvPair.ConvertToConfig(this.KeyToRemove, this.Parser);
         }
     }
 }

--- a/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationSource.cs
+++ b/src/Winton.Extensions.Configuration.Consul/ConsulConfigurationSource.cs
@@ -24,7 +24,7 @@ namespace Winton.Extensions.Configuration.Consul
 
             Key = key;
             Parser = new JsonConfigurationParser();
-            ConvertToConfig = DefaultConvertToConfigStrategy;
+            ConvertConsulKVPairToConfig = DefaultConvertConsulKVPairToConfigStrategy;
         }
 
         public Action<ConsulClientConfiguration>? ConsulConfigurationOptions { get; set; }
@@ -41,7 +41,7 @@ namespace Winton.Extensions.Configuration.Consul
             set => _keyToRemove = value;
         }
 
-        public Func<KVPair, IEnumerable<KeyValuePair<string, string>>> ConvertToConfig { get; set; }
+        public Func<KVPair, IEnumerable<KeyValuePair<string, string>>> ConvertConsulKVPairToConfig { get; set; }
 
         public Action<ConsulLoadExceptionContext>? OnLoadException { get; set; }
 
@@ -61,7 +61,7 @@ namespace Winton.Extensions.Configuration.Consul
             return new ConsulConfigurationProvider(this, consulClientFactory);
         }
 
-        private IEnumerable<KeyValuePair<string, string>> DefaultConvertToConfigStrategy(KVPair consulKvPair)
+        private IEnumerable<KeyValuePair<string, string>> DefaultConvertConsulKVPairToConfigStrategy(KVPair consulKvPair)
         {
             return consulKvPair.ConvertToConfig(this.KeyToRemove, this.Parser);
         }

--- a/src/Winton.Extensions.Configuration.Consul/Extensions/KVPairQueryResultExtensions.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Extensions/KVPairQueryResultExtensions.cs
@@ -22,11 +22,11 @@ namespace Winton.Extensions.Configuration.Consul.Extensions
 
         internal static Dictionary<string, string> ToConfigDictionary(
             this QueryResult<KVPair[]> result,
-            Func<KVPair, IEnumerable<KeyValuePair<string, string>>> convertToConfig)
+            Func<KVPair, IEnumerable<KeyValuePair<string, string>>> convertConsulKVPairToConfig)
         {
             return (result.Response ?? new KVPair[0])
                 .Where(kvp => kvp.HasValue())
-                .SelectMany(convertToConfig)
+                .SelectMany(convertConsulKVPairToConfig)
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.OrdinalIgnoreCase);
         }
     }

--- a/src/Winton.Extensions.Configuration.Consul/Extensions/KVPairQueryResultExtensions.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Extensions/KVPairQueryResultExtensions.cs
@@ -22,12 +22,11 @@ namespace Winton.Extensions.Configuration.Consul.Extensions
 
         internal static Dictionary<string, string> ToConfigDictionary(
             this QueryResult<KVPair[]> result,
-            string keyToRemove,
-            IConfigurationParser parser)
+            Func<KVPair, IEnumerable<KeyValuePair<string, string>>> convertToConfig)
         {
             return (result.Response ?? new KVPair[0])
                 .Where(kvp => kvp.HasValue())
-                .SelectMany(kvp => kvp.ConvertToConfig(keyToRemove, parser))
+                .SelectMany(convertToConfig)
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.OrdinalIgnoreCase);
         }
     }

--- a/src/Winton.Extensions.Configuration.Consul/IConsulConfigurationSource.cs
+++ b/src/Winton.Extensions.Configuration.Consul/IConsulConfigurationSource.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using Consul;
@@ -22,6 +23,14 @@ namespace Winton.Extensions.Configuration.Consul
         ///     Allows the default config options for Consul to be overriden.
         /// </summary>
         Action<ConsulClientConfiguration>? ConsulConfigurationOptions { get; set; }
+
+        /// <summary>
+        ///     Gets or sets a function taking a Consul <see cref="KVPair"/> to one or more
+        ///     string key/value pairs.  The default ConverToConfigStrategy is to remove
+        ///     the <see cref="KeyToRemove"/> portion of the Consul Key and then apply the
+        ///     configured <see cref="Parser"/> to parse the Consul value.
+        /// </summary>
+        Func<KVPair, IEnumerable<KeyValuePair<string, string>>> ConvertToConfig { get; set; }
 
         /// <summary>
         ///     Gets or sets an <see cref="Action" /> to be applied to the <see cref="HttpClientHandler" />

--- a/src/Winton.Extensions.Configuration.Consul/IConsulConfigurationSource.cs
+++ b/src/Winton.Extensions.Configuration.Consul/IConsulConfigurationSource.cs
@@ -30,7 +30,7 @@ namespace Winton.Extensions.Configuration.Consul
         ///     the <see cref="KeyToRemove"/> portion of the Consul Key and then apply the
         ///     configured <see cref="Parser"/> to parse the Consul value.
         /// </summary>
-        Func<KVPair, IEnumerable<KeyValuePair<string, string>>> ConvertToConfig { get; set; }
+        Func<KVPair, IEnumerable<KeyValuePair<string, string>>> ConvertConsulKVPairToConfig { get; set; }
 
         /// <summary>
         ///     Gets or sets an <see cref="Action" /> to be applied to the <see cref="HttpClientHandler" />

--- a/src/Winton.Extensions.Configuration.Consul/IConsulConfigurationSource.cs
+++ b/src/Winton.Extensions.Configuration.Consul/IConsulConfigurationSource.cs
@@ -25,11 +25,16 @@ namespace Winton.Extensions.Configuration.Consul
         Action<ConsulClientConfiguration>? ConsulConfigurationOptions { get; set; }
 
         /// <summary>
-        ///     Gets or sets a function taking a Consul <see cref="KVPair"/> to one or more
-        ///     string key/value pairs.  The default ConverToConfigStrategy is to remove
-        ///     the <see cref="KeyToRemove"/> portion of the Consul Key and then apply the
-        ///     configured <see cref="Parser"/> to parse the Consul value.
+        ///     Gets or sets a function taking a Consul <see cref="KVPair"/> to one or more key/value
+        ///     pairs which are injected into the Microsoft <see cref="IConfiguration"/> system.
         /// </summary>
+        /// <remarks>
+        ///     The default ConvertConsulKVPairToConfig strategy is to remove the
+        ///     <see cref="KeyToRemove"/> portion of the Consul Key and then apply the configured
+        ///     <see cref="Parser"/> to parse the Consul value.  Note that if you customize this strategy
+        ///     there are some requirements on the final format of
+        ///     <see href="https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-3.1#configuration-keys-and-values">Configuration Keys and Values</see>.
+        /// </remarks>
         Func<KVPair, IEnumerable<KeyValuePair<string, string>>> ConvertConsulKVPairToConfig { get; set; }
 
         /// <summary>

--- a/test/Winton.Extensions.Configuration.Consul.Test/ConsulConfigurationProviderTests.cs
+++ b/test/Winton.Extensions.Configuration.Consul.Test/ConsulConfigurationProviderTests.cs
@@ -676,9 +676,9 @@ namespace Winton.Extensions.Configuration.Consul
             }
         }
 
-        public sealed class CustomizeConvertToConfig : ConsulConfigurationProviderTests
+        public sealed class CustomizeConvertConsulKVPairToConfig : ConsulConfigurationProviderTests
         {
-            public CustomizeConvertToConfig()
+            public CustomizeConvertConsulKVPairToConfig()
             {
                 _source.ReloadOnChange = false;
             }
@@ -701,7 +701,7 @@ namespace Winton.Extensions.Configuration.Consul
                             StatusCode = HttpStatusCode.OK
                         });
 
-                _source.ConvertToConfig = kvPair =>
+                _source.ConvertConsulKVPairToConfig = kvPair =>
                 {
                     var normalizedKey = kvPair.Key
                       .Replace("__", ":")
@@ -742,7 +742,7 @@ namespace Winton.Extensions.Configuration.Consul
                             StatusCode = HttpStatusCode.OK
                         });
 
-                _source.ConvertToConfig = kvPair =>
+                _source.ConvertConsulKVPairToConfig = kvPair =>
                 {
                     var normalizedKey = kvPair.Key
                       .Replace("__", ":")

--- a/test/Winton.Extensions.Configuration.Consul.Test/ConsulConfigurationSourceTests.cs
+++ b/test/Winton.Extensions.Configuration.Consul.Test/ConsulConfigurationSourceTests.cs
@@ -66,13 +66,13 @@ namespace Winton.Extensions.Configuration.Consul
             }
 
             [Fact]
-            private void ShoulSetDefaultConvertToConfigStrategy()
+            private void ShoulSetDefaultConvertConsulKVPairToConfigStrategy()
             {
                 var source = new ConsulConfigurationSource("Key");
 
                 var consulKVPair = new KVPair("key") { Value = Encoding.UTF8.GetBytes("{\"a\": \"b\", \"c\": \"d\"}") };
 
-                var result = source.ConvertToConfig(consulKVPair);
+                var result = source.ConvertConsulKVPairToConfig(consulKVPair);
                 result.Should()
                     .NotBeEmpty()
                     .And.HaveCount(2)

--- a/test/Winton.Extensions.Configuration.Consul.Test/ConsulConfigurationSourceTests.cs
+++ b/test/Winton.Extensions.Configuration.Consul.Test/ConsulConfigurationSourceTests.cs
@@ -74,10 +74,7 @@ namespace Winton.Extensions.Configuration.Consul
 
                 var result = source.ConvertConsulKVPairToConfig(consulKVPair);
                 result.Should()
-                    .NotBeEmpty()
-                    .And.HaveCount(2)
-                    .And.Contain(kvp => kvp.Key == "key:a" && kvp.Value == "b")
-                    .And.Contain(kvp => kvp.Key == "key:c" && kvp.Value == "d");
+                    .BeEquivalentTo(new Dictionary<string, string> { { "key:a", "b" }, { "key:c", "d" } });
             }
         }
     }

--- a/test/Winton.Extensions.Configuration.Consul.Test/ConsulConfigurationSourceTests.cs
+++ b/test/Winton.Extensions.Configuration.Consul.Test/ConsulConfigurationSourceTests.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Consul;
 using FluentAssertions;
 using Winton.Extensions.Configuration.Consul.Parsers;
 using Xunit;
@@ -59,6 +63,21 @@ namespace Winton.Extensions.Configuration.Consul
                 Action constructing = () => new ConsulConfigurationSource(key);
 
                 constructing.Should().Throw<ArgumentNullException>().And.Message.Should().Contain("key");
+            }
+
+            [Fact]
+            private void ShoulSetDefaultConvertToConfigStrategy()
+            {
+                var source = new ConsulConfigurationSource("Key");
+
+                var consulKVPair = new KVPair("key") { Value = Encoding.UTF8.GetBytes("{\"a\": \"b\", \"c\": \"d\"}") };
+
+                var result = source.ConvertToConfig(consulKVPair);
+                result.Should()
+                    .NotBeEmpty()
+                    .And.HaveCount(2)
+                    .And.Contain(kvp => kvp.Key == "key:a" && kvp.Value == "b")
+                    .And.Contain(kvp => kvp.Key == "key:c" && kvp.Value == "d");
             }
         }
     }

--- a/test/Winton.Extensions.Configuration.Consul.Test/Extensions/KVPairExtensionsTests.cs
+++ b/test/Winton.Extensions.Configuration.Consul.Test/Extensions/KVPairExtensionsTests.cs
@@ -11,16 +11,16 @@ namespace Winton.Extensions.Configuration.Consul.Extensions
 {
     public class KVPairExtensionsTests
     {
-        public sealed class ConvertToConfig : KVPairExtensionsTests
+        public sealed class ConvertConsulKVPairToConfig : KVPairExtensionsTests
         {
             private readonly Mock<IConfigurationParser> _parserMock;
 
-            public ConvertToConfig()
+            public ConvertConsulKVPairToConfig()
             {
                 _parserMock = new Mock<IConfigurationParser>(MockBehavior.Strict);
             }
 
-            public static IEnumerable<object[]> ConvertToConfigTestCases => new List<object[]>
+            public static IEnumerable<object[]> ConvertConsulKVPairToConfigTestCases => new List<object[]>
             {
                 new object[]
                 {
@@ -136,7 +136,7 @@ namespace Winton.Extensions.Configuration.Consul.Extensions
             };
 
             [Theory]
-            [MemberData(nameof(ConvertToConfigTestCases))]
+            [MemberData(nameof(ConvertConsulKVPairToConfigTestCases))]
             private void ShouldConvertKVPairToConfigCorrectly(
                 string rootKey,
                 string kvPairKey,

--- a/test/Winton.Extensions.Configuration.Consul.Test/Extensions/KVPairQueryResultExtensionsTests.cs
+++ b/test/Winton.Extensions.Configuration.Consul.Test/Extensions/KVPairQueryResultExtensionsTests.cs
@@ -188,7 +188,7 @@ namespace Winton.Extensions.Configuration.Consul.Extensions
                     .Returns(new Dictionary<string, string> { { "key", "value" } });
                 _source.KeyToRemove = "test/path";
 
-                var config = result.ToConfigDictionary(_source.ConvertToConfig);
+                var config = result.ToConfigDictionary(_source.ConvertConsulKVPairToConfig);
 
                 config.Should().BeEmpty();
             }
@@ -200,8 +200,8 @@ namespace Winton.Extensions.Configuration.Consul.Extensions
                 {
                     Response = new[]
                     {
-                        new KVPair("path/test") { Value = new List<byte>().ToArray() }
-                    },
+               new KVPair("path/test") { Value = new List<byte>().ToArray() }
+            },
                     StatusCode = HttpStatusCode.OK
                 };
                 _parser
@@ -209,7 +209,7 @@ namespace Winton.Extensions.Configuration.Consul.Extensions
                     .Returns(new Dictionary<string, string>());
                 _source.KeyToRemove = "path/test";
 
-                var config = result.ToConfigDictionary(_source.ConvertToConfig);
+                var config = result.ToConfigDictionary(_source.ConvertConsulKVPairToConfig);
 
                 _parser.Verify(cp => cp.Parse(It.IsAny<MemoryStream>()), Times.Never);
             }
@@ -225,8 +225,8 @@ namespace Winton.Extensions.Configuration.Consul.Extensions
                 {
                     Response = new[]
                     {
-                        new KVPair("path/test") { Value = new List<byte> { 1 }.ToArray() }
-                    },
+              new KVPair("path/test") { Value = new List<byte> { 1 }.ToArray() }
+            },
                     StatusCode = HttpStatusCode.OK
                 };
                 _parser
@@ -234,7 +234,7 @@ namespace Winton.Extensions.Configuration.Consul.Extensions
                     .Returns(new Dictionary<string, string> { { "kEy", "value" } });
                 _source.KeyToRemove = "path/test";
 
-                var config = result.ToConfigDictionary(_source.ConvertToConfig);
+                var config = result.ToConfigDictionary(_source.ConvertConsulKVPairToConfig);
 
                 config.Should().ContainKey(key);
             }
@@ -246,8 +246,8 @@ namespace Winton.Extensions.Configuration.Consul.Extensions
                 {
                     Response = new[]
                     {
-                        new KVPair("path/test") { Value = new List<byte> { 1 }.ToArray() }
-                    },
+              new KVPair("path/test") { Value = new List<byte> { 1 }.ToArray() }
+            },
                     StatusCode = HttpStatusCode.OK
                 };
                 _parser
@@ -255,7 +255,7 @@ namespace Winton.Extensions.Configuration.Consul.Extensions
                     .Returns(new Dictionary<string, string> { { "Key", "Value" } });
                 _source.KeyToRemove = "path";
 
-                var config = result.ToConfigDictionary(_source.ConvertToConfig);
+                var config = result.ToConfigDictionary(_source.ConvertConsulKVPairToConfig);
 
                 config.Should().Contain(new KeyValuePair<string, string>("test:Key", "Value"));
             }


### PR DESCRIPTION
The current strategy for parsing consul `KVPairs` into `IConfiguration` data makes a few key assumptions:

- `IConfigurationParser` implementations can parse consul `Values` without any knowledge of the consul Key; and

- `IConfigurationParser` implementations are not concerned with parsing the consul `Keys` themselves

- The only manipulation of consul `Keys` required is the optional removal of a prefix (e.g. `KeyToRemove`)

By pulling a `Func<KVPair, IEnumerable<KeyValuePair<string, string>>>` property up to `IConsulConfigurationSource` we now allow clients to bypass these assumptions and fully customize the `ConvertToConfig` step of providing `IConfiguration data` from a consul KV store.

The new `ConvertToConfig` property is now passed to the `KVPairQueryResultExtensions.ToConfigDictionary(..)` method instead of the `IConsulConfigurationSource` `Parser` and `KeyToRemove` properties and a new private `DefaultConvertToConfigStrategy` method in the `ConsulConfigurationSource` class handles simulating the current behaviour, invoking the `KVPairExtensions.ToConfigDictionary` method with `KeyToRemove` and `Parser` as before.

```csharp
builder
    .AddConsul(
        "myApp",
        options =>
        {
            options.ConvertToConfig = kvPair =>
            {
                var normalizedKey = kvPair.Key
                    .Replace(_source.KeyToRemove, string.Empty)
                    .Replace("__", "/")
                    .Replace("/", ":")
                    .Trim('/');
                using Stream valueStream = new MemoryStream(kvPair.Value);
                using var streamReader = new StreamReader(valueStream);
                var parsedValue = streamReader.ReadToEnd();
                return new Dictionary<string, string>()
                {
                    { normalizedKey, parsedValue }
                };
            };
        });
```

This is a non-breaking change as clients who do not override the default value for `ConsulConfigurationSource.ConvertToConfig` will continue to use the `DefaultConvertToConfigStrategy`.

Clients who wish, however, can now completely intercept the processing of consul `KVPairs` and use the full consul key and raw consul value to perform whatever post-fetch processing required.

Addresses #101 