### PR TITLE
Publish symbols to NuGet.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,10 @@ env:
   global:
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     - DOTNET_CLI_TELEMETRY_OPTOUT: 1
-matrix:
+jobs:
   include:
     - os: linux
       dist: bionic
-      sudo: required
       dotnet: 3.0
     - os: osx 
       osx_image: xcode11.2
@@ -22,7 +21,3 @@ matrix:
 script:
   - git fetch --unshallow
   - ./build.sh
-notifications:
-  on_success: always
-  on_failure: always
-  on_start: always

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Winton.Extensions.Configuration.Consul
 
-[![Build status](https://ci.appveyor.com/api/projects/status/vlouj9n5ahqsgql9/branch/master?svg=true)](https://ci.appveyor.com/project/wintoncode/winton-extensions-configuration-consul/branch/master)
-[![Travis Build Status](https://travis-ci.org/wintoncode/Winton.Extensions.Configuration.Consul.svg?branch=master)](https://travis-ci.org/wintoncode/Winton.Extensions.Configuration.Consul)
+[![Appveyor](https://ci.appveyor.com/api/projects/status/vlouj9n5ahqsgql9/branch/master?svg=true)](https://ci.appveyor.com/project/wintoncode/winton-extensions-configuration-consul/branch/master)
+[![Travis CI](https://travis-ci.com/wintoncode/Winton.Extensions.Configuration.Consul.svg?branch=master)](https://travis-ci.com/wintoncode/Winton.Extensions.Configuration.Consul)
 [![NuGet version](https://img.shields.io/nuget/v/Winton.Extensions.Configuration.Consul.svg)](https://www.nuget.org/packages/Winton.Extensions.Configuration.Consul)
 [![NuGet version](https://img.shields.io/nuget/vpre/Winton.Extensions.Configuration.Consul.svg)](https://www.nuget.org/packages/Winton.Extensions.Configuration.Consul)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,3 @@
-version: "{build}"
 environment:
     CLI_VERSION: latest
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -6,7 +5,6 @@ environment:
 image: Visual Studio 2019
 configuration:
     - Release
-skip_tags: true
 before_build:
     - dotnet tool install -g GitVersion.Tool
     - dotnet gitversion /l console /output buildserver
@@ -14,11 +12,6 @@ build_script:
     - dotnet build -c Release -p:Version=%GitVersion_NuGetVersion%
 test_script:
     - dotnet test -c Release --no-build
-artifacts:
-    - path: .\**\*.nupkg
-      name: NuGet
-nuget:
-    disable_publish_on_pr: true
 deploy:
     - provider: NuGet
       api_key:

--- a/src/Winton.Extensions.Configuration.Consul/Winton.Extensions.Configuration.Consul.csproj
+++ b/src/Winton.Extensions.Configuration.Consul/Winton.Extensions.Configuration.Consul.csproj
@@ -17,10 +17,6 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
@@ -34,6 +30,7 @@
     <PackageReference Include="Consul" Version="0.7.2.6" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Following on from #104 which enabled SourceLink I have cleaned up and simplified the `appveyor.yml` file so that it publishes symbol packages too. 

Also, made some minor changes to the travis settings as I ported our builds from travis-ci.org to travis-ci.com and started using the newer Travis CI GitHub App for build integrations. You can see that Travis builds now show up under the "checks" tab.