### PR TITLE
Fix issue with forward slashes in JSON keys being converted to colons.

### DIFF
--- a/src/Winton.Extensions.Configuration.Consul/Extensions/KVPairExtensions.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Extensions/KVPairExtensions.cs
@@ -22,8 +22,7 @@ namespace Winton.Extensions.Configuration.Consul.Extensions
                 .Select(
                     pair =>
                     {
-                        var key = $"{kvPair.Key.RemoveStart(keyToRemove).TrimEnd('/')}:{pair.Key}"
-                            .Replace('/', ':')
+                        var key = $"{kvPair.Key.RemoveStart(keyToRemove).TrimEnd('/').Replace('/', ':')}:{pair.Key}"
                             .Trim(':');
                         if (string.IsNullOrEmpty(key))
                         {

--- a/test/Winton.Extensions.Configuration.Consul.Test/Extensions/KVPairExtensionsTests.cs
+++ b/test/Winton.Extensions.Configuration.Consul.Test/Extensions/KVPairExtensionsTests.cs
@@ -55,7 +55,7 @@ namespace Winton.Extensions.Configuration.Consul.Extensions
                 new object[]
                 {
                     "RootKey/Settings",
-                    "RootKey/Settings/Root",
+                    "RootKey/Settings/Root/",
                     new Dictionary<string, string> { { "Key", "value" } },
                     new[]
                     {
@@ -131,6 +131,16 @@ namespace Winton.Extensions.Configuration.Consul.Extensions
                     new[]
                     {
                         new KeyValuePair<string, string>("Section:Key", "value")
+                    }
+                },
+                new object[]
+                {
+                    string.Empty,
+                    "Root/Section",
+                    new Dictionary<string, string> { { "JsonKey/With/Slash", "value" } },
+                    new[]
+                    {
+                        new KeyValuePair<string, string>("Root:Section:JsonKey/With/Slash", "value")
                     }
                 }
             };

--- a/test/Winton.Extensions.Configuration.Consul.Test/Parsers/JsonConfigurationParserTests.cs
+++ b/test/Winton.Extensions.Configuration.Consul.Test/Parsers/JsonConfigurationParserTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using FluentAssertions;
@@ -16,14 +17,33 @@ namespace Winton.Extensions.Configuration.Consul.Parsers
 
         public sealed class Parse : JsonConfigurationParserTests
         {
+            public static IEnumerable<object[]> TestCases => new List<object[]>
+            {
+                new object[]
+                {
+                    "{\"Key\": \"Value\"}",
+                    new Dictionary<string, string> { { "Key", "Value" } }
+                },
+                new object[]
+                {
+                    "{\"parent\": {\"child\": \"Value\"} }",
+                    new Dictionary<string, string?> { { "parent", null }, { "parent:child", "Value" } }
+                },
+                new object[]
+                {
+                    "{\"Key/WithSlash\": \"Value\"}",
+                    new Dictionary<string, string> { { "Key/WithSlash", "Value" } }
+                }
+            };
+
             [Theory]
-            [InlineData("{\"Key\": \"Value\"}", "Key", "Value")]
-            [InlineData("{\"parent\": {\"child\": \"Value\"} }", "parent:child", "Value")]
-            private void ShouldParseSimpleJsonFromStream(string json, string key, string expectedValue)
+            [MemberData(nameof(TestCases))]
+            private void ShouldParseSimpleJsonFromStream(string json, IDictionary<string, string?> expected)
             {
                 using Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
                 var result = _parser.Parse(stream);
-                result[key].Should().Be(expectedValue);
+
+                result.Should().BeEquivalentTo(expected);
             }
         }
     }


### PR DESCRIPTION
Fixes an issue with the parsing of JSON config values whereby if the JSON keys contain a forward slash they are converted to colons.

Addresses #113 