### PR TITLE
Remove null value pair when parse jsonconfiguration to dictionary .

### DIFF
--- a/src/Winton.Extensions.Configuration.Consul/Parsers/JsonConfigurationParser.cs
+++ b/src/Winton.Extensions.Configuration.Consul/Parsers/JsonConfigurationParser.cs
@@ -3,8 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Json;
 
 namespace Winton.Extensions.Configuration.Consul.Parsers
 {
@@ -14,14 +13,29 @@ namespace Winton.Extensions.Configuration.Consul.Parsers
     /// </summary>
     public sealed class JsonConfigurationParser : IConfigurationParser
     {
-        /// <inheritdoc />
+        /// <summary>
+        /// Parse the <see cref="Stream" /> into a dictionary.
+        /// </summary>
+        /// <param name="stream">The stream to parse.</param>
+        /// <returns>A dictionary representing the configuration in a flattened form.</returns>
         public IDictionary<string, string> Parse(Stream stream)
         {
-            return new ConfigurationBuilder()
-                .AddJsonStream(stream)
-                .Build()
-                .AsEnumerable()
-                .ToDictionary(pair => pair.Key, pair => pair.Value);
+            return JsonStreamParser.Parse(stream);
+        }
+
+        private sealed class JsonStreamParser : JsonStreamConfigurationProvider
+        {
+            private JsonStreamParser(JsonStreamConfigurationSource source)
+                : base(source)
+            {
+            }
+
+            internal static IDictionary<string, string> Parse(Stream stream)
+            {
+                var provider = new JsonStreamParser(new JsonStreamConfigurationSource { Stream = stream });
+                provider.Load();
+                return provider.Data;
+            }
         }
     }
 }

--- a/test/Winton.Extensions.Configuration.Consul.Test/Parsers/JsonConfigurationParserTests.cs
+++ b/test/Winton.Extensions.Configuration.Consul.Test/Parsers/JsonConfigurationParserTests.cs
@@ -27,7 +27,12 @@ namespace Winton.Extensions.Configuration.Consul.Parsers
                 new object[]
                 {
                     "{\"parent\": {\"child\": \"Value\"} }",
-                    new Dictionary<string, string?> { { "parent", null }, { "parent:child", "Value" } }
+                    new Dictionary<string, string?> { { "parent:child", "Value" } }
+                },
+                new object[]
+                {
+                    "{\"server\": {\"ip\": \"192.168.0.1\", \"port\": 5000} }",
+                    new Dictionary<string, string?> { { "server:ip", "192.168.0.1" }, { "server:port", "5000" } }
                 },
                 new object[]
                 {


### PR DESCRIPTION
when read a josn string from consul server like this :
```
{
  "Logging": {
    "LogLevel": {
      "Default": "Information",
      "Microsoft": "Warning",
      "Microsoft.Hosting.Lifetime": "Information"
    }
  },
  "AllowedHosts": "*",
  "server": {
  	"ip":"192.168.0.1",
    "port": 5000
  }
}
```
the JsonConfigurationParser class will parse it to a dictionary . but when json element is an object , it will convert to a null value pair .   
![image](https://user-images.githubusercontent.com/3354922/125486965-043af0f0-30e2-4bcb-9f26-9665139c5802.png)
    
this pr fix this problem .